### PR TITLE
Feature/aeid 84b

### DIFF
--- a/deploy/instances/test-norails.yml
+++ b/deploy/instances/test-norails.yml
@@ -1,2 +1,3 @@
 deployer_env: norails
+default_branch: master
 

--- a/deploy/instances/test-rails.yml
+++ b/deploy/instances/test-rails.yml
@@ -1,2 +1,3 @@
 deployer_env: rails
+default_branch: master
 

--- a/deploy/stages/test-norails.rb
+++ b/deploy/stages/test-norails.rb
@@ -2,8 +2,7 @@ set :application, "test-norails"
 
 # We must use a public repo because our ssh key hasn't been added anywhere
 set :repo_url, "https://github.com/dpn-admin/dpn-client.git"
-set :branch, "master"
-set :branch, ENV['BRANCH'] if ENV['BRANCH']
+set :branch, ENV['BRANCH']
 set :deploy_to, File.expand_path(File.join(File.dirname(__FILE__), "../../spec/sandbox/test-norails"))
 set :rails_env, "production"
 set :assets_prefix, "assets"

--- a/deploy/stages/test-rails.rb
+++ b/deploy/stages/test-rails.rb
@@ -2,8 +2,7 @@ set :application, "test-rails"
 
 # We must use a public repo because our ssh key hasn't been added anywhere
 set :repo_url, "https://github.com/mlibrary/chipmunk.git"
-set :branch, "master"
-set :branch, ENV['BRANCH'] if ENV['BRANCH']
+set :branch, ENV['BRANCH']
 set :deploy_to, File.expand_path(File.join(File.dirname(__FILE__), "../../spec/sandbox/test-rails"))
 set :rails_env, "development"
 set :assets_prefix, "assets"

--- a/lib/fauxpaas/capistrano_deployer.rb
+++ b/lib/fauxpaas/capistrano_deployer.rb
@@ -8,9 +8,9 @@ module Fauxpaas
       @kernel = kernel
     end
 
-    def deploy(instance,branch: 'master')
+    def deploy(instance, reference: nil)
       instance_capfile_path = capfile_path + "#{instance.deployer_env}.capfile"
-      kernel.system("cap -f #{instance_capfile_path} #{instance.name} deploy BRANCH=#{branch}")
+      kernel.system("cap -f #{instance_capfile_path} #{instance.name} deploy BRANCH=#{reference || instance.default_branch}")
     end
 
     private

--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -6,16 +6,31 @@ module Fauxpaas
 
     class Main < Thor
 
-      option :branch,
-          type: :string,
-          default: "master",
-          desc: "The branch or revision to deploy"
+      option :reference,
+        type: :string,
+        aliases: ["-r", "--branch", "--commit"],
+        desc: "The branch or commit to deploy. " +
+          "Use default_branch to display or set the default branch."
 
       desc "deploy <instance>",
-      "Deploys the instance's source; by default deploys master. Use --branch to deploy a specific revision"
+        "Deploys the instance."
       def deploy(instance_name)
         instance = Fauxpaas.instance_repo.find(instance_name)
-        Fauxpaas.deployer.deploy(instance,branch: :branch)
+        Fauxpaas.deployer.deploy(instance, reference: options[:reference])
+      end
+
+      desc "default_branch <instance> [<new_branch>]",
+        "Display or set the default branch for the instance"
+      def default_branch(instance_name, new_branch = nil)
+        instance = Fauxpaas.instance_repo.find(instance_name)
+        if new_branch
+          old_branch = instance.default_branch
+          instance.default_branch = new_branch
+          Fauxpass.instance_repo.save(instance)
+          puts "Changed default branch from #{old_branch} to #{new_branch}"
+        else
+          puts "Default branch: #{instance.default_branch}"
+        end
       end
     end
 

--- a/lib/fauxpaas/file_instance_repo.rb
+++ b/lib/fauxpaas/file_instance_repo.rb
@@ -15,14 +15,18 @@ module Fauxpaas
       contents = YAML.load(fs.read(path + "#{name}.yml"))
       Instance.new(
         name: name,
-        deployer_env: contents["deployer_env"]
+        deployer_env: contents["deployer_env"],
+        default_branch: contents["default_branch"]
       )
     end
 
     def save(instance)
       save_path = path + "#{instance.name}.yml"
       fs.mkdir_p(save_path)
-      fs.write(save_path, YAML.dump("deployer_env" => instance.deployer_env))
+      fs.write(save_path, YAML.dump(
+        "deployer_env" => instance.deployer_env,
+        "default_branch" => instance.default_branch
+      ))
     end
 
     private

--- a/lib/fauxpaas/instance.rb
+++ b/lib/fauxpaas/instance.rb
@@ -5,12 +5,14 @@ module Fauxpaas
   # Represents a named instance within fauxpaas, as opposed
   # to installed on destination servers.
   class Instance
-    def initialize(name:, deployer_env:)
+    def initialize(name:, deployer_env:, default_branch: "master")
       @app, @stage = name.split("-")
       @deployer_env = deployer_env
+      @default_branch = default_branch
     end
 
-    attr_reader :app, :stage, :deployer_env
+    attr_reader :app, :stage, :deployer_env, :default_branch
+    attr_writer :default_branch
 
     def name
       "#{app}-#{stage}"

--- a/spec/capistrano_deployer_spec.rb
+++ b/spec/capistrano_deployer_spec.rb
@@ -8,22 +8,24 @@ module Fauxpaas
     let(:kernel) { double(:kernel, system: nil) }
 
     let(:instance) do
-      double(:instance, name: "myapp-staging", deployer_env: "rails")
+      double(:instance,
+        name: "myapp-staging",
+        deployer_env: "rails",
+        default_branch: "develop")
     end
 
     let(:deployer) { described_class.new(path, kernel) }
 
     describe "#deploy" do
-      it "invokes capistrano and deploys the master branch" do
+      it "gets the default from the instance" do
         expect(kernel).to receive(:system)
-          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy BRANCH=master")
+          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy BRANCH=#{instance.default_branch}")
         deployer.deploy(instance)
       end
-
-      it "can invoke capistrano with an arbitrary branch/revision" do
+      it "deploys the given branch or commit" do
         expect(kernel).to receive(:system)
-          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy BRANCH=deadbeef")
-        deployer.deploy(instance,branch: 'deadbeef')
+          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy BRANCH=master")
+        deployer.deploy(instance, reference: "master")
       end
     end
 

--- a/spec/file_instance_repo_spec.rb
+++ b/spec/file_instance_repo_spec.rb
@@ -14,11 +14,21 @@ module Fauxpaas
 
     let(:name) { "myapp-mystage" }
     let(:deployer_env) { "something" }
+    let(:default_branch) { "somebranch" }
     let(:instance) do
-      Instance.new(name: name, deployer_env: deployer_env)
+      Instance.new(
+        name: name,
+        deployer_env: deployer_env,
+        default_branch: default_branch
+      )
     end
 
-    let(:contents) { YAML.dump("deployer_env" => deployer_env) }
+    let(:contents) do
+      YAML.dump(
+        "deployer_env" => deployer_env,
+        "default_branch" => default_branch
+      )
+    end
 
     describe "#find" do
       it "returns the corresponding instance" do

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -9,10 +9,12 @@ module Fauxpaas
     let(:stage) { "mystage" }
     let(:name) { "#{app}-#{stage}" }
     let(:deployer_env) { double(:deployer_env) }
+    let(:somebranch) { "somebranch" }
     let(:instance) do
       described_class.new(
         name: name,
-        deployer_env: deployer_env
+        deployer_env: deployer_env,
+        default_branch: somebranch
       )
     end
 
@@ -37,6 +39,24 @@ module Fauxpaas
     describe "#deployer_env" do
       it "returns the deployer_env" do
         expect(instance.deployer_env).to eql(deployer_env)
+      end
+    end
+
+    describe "#default_branch" do
+      it "defaults to master" do
+        instance = described_class.new(
+          name: "asdf",
+          deployer_env: deployer_env
+        )
+        expect(instance.default_branch).to eql("master")
+      end
+      it "returns the branch" do
+        expect(instance.default_branch).to eql("somebranch")
+      end
+      it "can be set" do
+        expect { instance.default_branch = "newbranch" }
+          .to change { instance.default_branch }
+          .from(somebranch).to("newbranch")
       end
     end
 


### PR DESCRIPTION
Generally, applies my suggestions from PR #2.

* Condenses default branch support down to a single source of truth, the instance(.yml). 
* Adds a cli command to display or set the default branch
* Separates cli deploy revision support into the --revision option, for clarity. 

I went with this approach because the instance is not available when the command help is displayed, so we cannot display a dynamically discovered default branch for the specific instance.  This was necessary because we want the deploy command to be as simple as possible in most cases.