### PR TITLE
Feature/85/rollback simple

### DIFF
--- a/lib/fauxpaas/capistrano_deployer.rb
+++ b/lib/fauxpaas/capistrano_deployer.rb
@@ -17,6 +17,14 @@ module Fauxpaas
       return status
     end
 
+    def rollback(instance, cache: nil)
+      instance_capfile_path = capfile_path + "#{instance.deployer_env}.capfile"
+      stdout, stderr, status = kernel.capture3(
+        "cap -f #{instance_capfile_path} #{instance.name} deploy:rollback #{rollback_cache_option(cache)}".strip
+      )
+      return status
+    end
+
     def caches(instance)
       instance_capfile_path = capfile_path + "#{instance.deployer_env}.capfile"
       stdout, stderr, status = kernel.capture3(
@@ -31,6 +39,14 @@ module Fauxpaas
 
     private
     attr_reader :capfile_path, :kernel
+
+    def rollback_cache_option(cache)
+      if cache
+        "ROLLBACK_RELEASE=#{cache}"
+      else
+        ""
+      end
+    end
 
   end
 

--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -35,6 +35,7 @@ module Fauxpaas
 
       option :cache,
         type: :string,
+        aliases: "-c",
         desc: "The specific cache to rollback to. Defaults to the latest." +
           "Use with care."
       desc "rollback <instance> [<cache>]",

--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -33,6 +33,17 @@ module Fauxpaas
         end
       end
 
+      option :cache,
+        type: :string,
+        desc: "The specific cache to rollback to. Defaults to the latest." +
+          "Use with care."
+      desc "rollback <instance> [<cache>]",
+        "Rollsback to the specified cache, or the most recent one."
+      def rollback(instance_name)
+        instance = Fauxpaas.instance_repo.find(instance_name)
+        Fauxpaas.deployer.rollback(instance, cache: options[:cache])
+      end
+
       desc "caches <instance>",
         "List cached releases for the instance"
       def caches(instance_name)

--- a/spec/capistrano_deployer_spec.rb
+++ b/spec/capistrano_deployer_spec.rb
@@ -32,6 +32,20 @@ module Fauxpaas
       end
     end
 
+    describe "#rollback" do
+      let(:cache) { "20160614133327" }
+      it "invokes capistrano with ROLLBACK_RELEASE when a cache supplied" do
+        expect(kernel).to receive(:capture3)
+          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy:rollback ROLLBACK_RELEASE=#{cache}")
+        deployer.rollback(instance, cache: cache)
+      end
+      it "invokes capistrano without ROLLBACK_RELEASE when no cache supplied" do
+        expect(kernel).to receive(:capture3)
+          .with("cap -f #{path}/#{instance.deployer_env}.capfile #{instance.name} deploy:rollback")
+        deployer.rollback(instance)
+      end
+    end
+
     describe "#caches" do
       it "invokes capistrano" do
         expect(kernel).to receive(:capture3)


### PR DESCRIPTION
Adds support for simple rollbacks to the latest cache by default, or a specific cache. Notably, we just use capistrano's idea of a cache name--a datestamped dir--instead of something more advanced and domain specific. 