### PR TITLE
Add bin/test-console, which includes a cap pass-through

### DIFF
--- a/bin/test-console
+++ b/bin/test-console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "fauxpaas"
+require "fauxpaas/cli/test"
+
+Fauxpaas::CLI::Test.start(ARGV)

--- a/lib/fauxpaas/cli/test.rb
+++ b/lib/fauxpaas/cli/test.rb
@@ -1,0 +1,22 @@
+require "fauxpaas/configuration"
+require "fauxpaas/cli/main"
+
+module Fauxpaas
+  module CLI
+
+    class Test < Main
+      desc "cap <instance> [<task>]",
+        "Runs a capistrano command, with some nice defaults"
+      def cap(instance_name, task = "doctor")
+        Fauxpaas.config = configuration(options)
+        instance = Fauxpaas.instance_repo.find(instance_name)
+        instance_capfile_path = Fauxpaas.deployer.send(:capfile_path) + "#{instance.deployer_env}.capfile"
+        puts Kernel.system(
+          "cap -f #{instance_capfile_path} #{instance.name} #{task} " +
+            "BRANCH=#{instance.default_branch}"
+        )
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
As we add more options to the cap command, it becomes cumbersome to test cap directly. This tries to alleviate that somewhat.