### PR TITLE
Log releases in a separate file from instance.yml

### DIFF
--- a/deploy/instances/test-norails/instance.yml
+++ b/deploy/instances/test-norails/instance.yml
@@ -1,15 +1,15 @@
-source:
-  url: "https://github.com/dpn-admin/dpn-client.git"
-  git_runner: "Fauxpaas::RemoteGitRunner"
-  default_branch: master
+---
 deploy:
   url: "."
-  git_runner: "Fauxpaas::LocalGitRunner"
+  git_runner: Fauxpaas::LocalGitRunner
   default_branch: HEAD
   root_dir: deploy/instances/test-norails
+source:
+  url: https://github.com/dpn-admin/dpn-client.git
+  git_runner: Fauxpaas::RemoteGitRunner
+  default_branch: master
 infrastructure:
   url: "."
-  git_runner: "Fauxpaas::LocalGitRunner"
+  git_runner: Fauxpaas::LocalGitRunner
   default_branch: HEAD
   root_dir: deploy/instances/test-norails
-releases: []

--- a/deploy/instances/test-norails/releases.yml
+++ b/deploy/instances/test-norails/releases.yml
@@ -1,0 +1,26 @@
+---
+releases:
+- :user: bhock
+  :time: '2017-11-13T11:31:36'
+  :signature:
+    :source:
+      :url: https://github.com/dpn-admin/dpn-client.git
+      :reference: 031d744fe4228d2440830d59d070a8598ac19da0
+    :infrastructure:
+      :url: "."
+      :reference: d8354414fdd500469c984733c08daf57a066bcfb
+    :deploy:
+      :url: "."
+      :reference: d8354414fdd500469c984733c08daf57a066bcfb
+- :user: bhock
+  :time: '2017-11-13T11:32:00'
+  :signature:
+    :source:
+      :url: https://github.com/dpn-admin/dpn-client.git
+      :reference: 031d744fe4228d2440830d59d070a8598ac19da0
+    :infrastructure:
+      :url: "."
+      :reference: d8354414fdd500469c984733c08daf57a066bcfb
+    :deploy:
+      :url: "."
+      :reference: d8354414fdd500469c984733c08daf57a066bcfb

--- a/deploy/instances/test-rails/instance.yml
+++ b/deploy/instances/test-rails/instance.yml
@@ -1,15 +1,15 @@
-source:
-  url: "https://github.com/mlibrary/chipmunk.git"
-  git_runner: "Fauxpaas::RemoteGitRunner"
-  default_branch: master
+---
 deploy:
   url: "."
-  git_runner: "Fauxpaas::LocalGitRunner"
+  git_runner: Fauxpaas::LocalGitRunner
   default_branch: HEAD
   root_dir: deploy/instances/test-rails
+source:
+  url: https://github.com/mlibrary/chipmunk.git
+  git_runner: Fauxpaas::RemoteGitRunner
+  default_branch: master
 infrastructure:
   url: "."
-  git_runner: "Fauxpaas::LocalGitRunner"
+  git_runner: Fauxpaas::LocalGitRunner
   default_branch: HEAD
   root_dir: deploy/instances/test-rails
-releases: []

--- a/spec/file_instance_repo_spec.rb
+++ b/spec/file_instance_repo_spec.rb
@@ -20,6 +20,13 @@ module Fauxpaas
       expect(YAML.load(mem_fs.read("/instances/test-norails/instance.yml"))).to eql(contents_before)
     end
 
+    it "can save and find instances" do
+      contents_before = YAML.load(File.read(Fauxpaas.instance_root + "test-norails" + "releases.yml"))
+      instance = static_repo.find("test-norails")
+      tmp_repo.save(instance)
+      expect(YAML.load(mem_fs.read("/instances/test-norails/releases.yml"))).to eql(contents_before)
+    end
+
     it "creates the directory to save in" do
       expect(mem_fs).to receive(:mkdir_p).with(Pathname.new("/instances/test-norails"))
       instance = static_repo.find("test-norails")


### PR DESCRIPTION
This PR simply moves the logging to a separate file in the instance storage dir, releases.yml. 

Resolves AEID-130