### PR TITLE
verbose option

### DIFF
--- a/lib/fauxpaas.rb
+++ b/lib/fauxpaas.rb
@@ -21,6 +21,7 @@ require "fauxpaas/open3_capture"
 require "fauxpaas/release"
 require "fauxpaas/release_signature"
 require "fauxpaas/remote_git_runner"
+require "fauxpaas/verbose_system_runner"
 
 # Fake Platform As A Service
 module Fauxpaas

--- a/lib/fauxpaas/components.rb
+++ b/lib/fauxpaas/components.rb
@@ -38,6 +38,10 @@ module Fauxpaas
       @split_token ||= File.read(root + ".split_token").chomp.freeze
     end
 
+    def system_runner=(new_runner)
+      @system_runner = new_runner
+    end
+
   end
 
 end

--- a/lib/fauxpaas/verbose_system_runner.rb
+++ b/lib/fauxpaas/verbose_system_runner.rb
@@ -1,0 +1,28 @@
+require "fauxpaas/open3_capture"
+
+module Fauxpaas
+  class VerboseSystemRunner
+    def initialize(runner: Open3Capture.new)
+      @runner = runner
+    end
+
+    def run(string)
+      puts "Executing '#{string}'"
+      runner.run(string).tap { |output| report(output) }
+    end
+
+    def report(output)
+      stdout,stderr,status = output
+
+      puts "Command STDOUT"
+      puts stdout
+      puts "Command STDERR"
+      puts stderr
+      puts "Command exited with status #{status}"
+    end
+
+    private
+
+    attr_reader :runner
+  end
+end

--- a/spec/verbose_system_runner_spec.rb
+++ b/spec/verbose_system_runner_spec.rb
@@ -1,0 +1,38 @@
+require_relative "./spec_helper"
+require "fauxpaas/verbose_system_runner"
+
+module Fauxpaas
+  RSpec.describe VerboseSystemRunner do
+
+    describe "#run" do
+      let(:mock_runner) do
+        double(:runner,
+               run: ['stdout','stderr',double(:status)])
+      end
+
+      let(:command) { "/bin/something" }
+      subject { described_class.new(runner: mock_runner).run(command) }
+
+      it "emits the listed command" do
+        expect { subject }.to output(/#{command}/).to_stdout
+      end
+
+      it "emits stdout from the command" do
+        expect { subject }.to output(/stdout/).to_stdout
+      end
+
+      it "emits stderr from the command" do
+        expect { subject }.to output(/stderr/).to_stdout
+      end
+
+      it "returns the same thing as its delegate" do
+        expect(subject).to eql(mock_runner.run(command))
+      end
+
+      it "delegates running the command to the given runner" do
+        expect(mock_runner).to receive(:run).with(command)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes AEID-129.

One thing to consider is how you feel about `Fauxpaas.system_runner=`. If you have another thought for how that should work, let me know... There is a potential issue where ordering matters - if the `backend_runner` gets constructed in components before you set the `system_runner`, the `backend_runner` doesn't get updated. That isn't trivial to fix, because even if you added a `backend_runner=` method you wouldn't necessarily know how the previous backend runner was created in order to build a new one with the new system runner... I don't know if this is important enough to address now, but either way I'm interested in your thoughts on how the top-level config could work.

CLI::Main is starting to get a bit ugly, but it has no tests. I'll take a look at addressing that separately - the main issue is just stubbing out all the components.