### PR TITLE
AEID-108 - Add restart to the end of successful deploys

### DIFF
--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -31,11 +31,12 @@ module Fauxpaas
         signature = instance.signature(options[:reference])
         release = instance.release(signature)
         status = release.deploy
+        report(status, action: "deploy")
         if status.success?
           instance.log_release(LoggedRelease.new(ENV["USER"], Time.now, signature))
           Fauxpaas.instance_repo.save(instance)
+          restart(instance_name)
         end
-        report(status, action: "deploy")
       end
 
       desc "default_branch <instance> [<new_branch>]",

--- a/spec/cli/main_spec.rb
+++ b/spec/cli/main_spec.rb
@@ -69,7 +69,16 @@ module Fauxpaas
 
       it "restarts the application" do
         expect(mock_cap).to receive(:restart)
-        cli.start(["restart", instance_name])
+        cli.start(["deploy", instance_name])
+      end
+
+      context "when it fails to deploy" do
+        let(:mock_status) { double(:status, success?: false) }
+
+        it "doesn't restart the application" do
+          expect(mock_cap).not_to receive(:restart)
+          cli.start(["deploy", instance_name])
+        end
       end
     end
 

--- a/spec/cli/main_spec.rb
+++ b/spec/cli/main_spec.rb
@@ -36,11 +36,13 @@ module Fauxpaas
         instance_double(Release,
           deploy: mock_status)
       end
+      let(:mock_cap) { instance_double(Cap, restart: mock_status) }
 
       before(:each) do
         allow(mock_instance).to receive(:release).and_return(mock_release)
         allow(mock_instance).to receive(:signature)
         allow(mock_instance).to receive(:log_release)
+        allow(mock_instance).to receive(:interrogator).and_return(mock_cap)
       end
 
       it_behaves_like "a Fauxpaas thor command", "deploy"
@@ -63,6 +65,11 @@ module Fauxpaas
       it "reports success" do
         expect { cli.start(["deploy", instance_name]) }
           .to output(/deploy successful/).to_stdout
+      end
+
+      it "restarts the application" do
+        expect(mock_cap).to receive(:restart)
+        cli.start(["restart", instance_name])
       end
     end
 


### PR DESCRIPTION
* Adds a restart command as the final step in deployment
* Ensures that success/fail output is generated for the deploy and the
  restart
* Does not run on failed deploys
* Works with test-norails
* Allows test-rails to successfully deploy, but fail to restart

* Resolves AEID-108
* Resolves AEID-127