### PR TITLE
AEID-96 - developer can view journalctl log

### DIFF
--- a/deploy/cap/restart.rb
+++ b/deploy/cap/restart.rb
@@ -3,7 +3,6 @@
 namespace :systemd do
   desc "Restart the application's systemd service"
   task :restart do
-    set :systemd_services, ENV.fetch("SYSTEMD_SERVICES", "").split(":")
     fetch(:systemd_services).each do |service|
       on roles(:app) do
         execute :sudo, "/bin/systemctl", "restart", service

--- a/deploy/cap/syslog.rb
+++ b/deploy/cap/syslog.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "pry"
+
+namespace :syslog do
+  def journalctl_cmd(initial: [:sudo, "/bin/journalctl"])
+    fetch(:systemd_services).reduce(initial) {|memo, obj| memo + ["-u", obj] }
+  end
+
+  def quote(arg)
+    '"' + arg.gsub(/(["\\])/, '\\1') + '"'
+  end
+
+  desc "View the system log for the application's systemd service"
+  task :view do
+    on roles(:app) do
+      execute(*journalctl_cmd) unless fetch(:systemd_services).empty?
+    end
+  end
+
+  desc "Grep the system log for the application's systemd service (set GREP_PATTERN)"
+  task :grep do
+    set :grep_pattern, ENV.fetch("GREP_PATTERN", ".")
+    on roles(:app) do
+      execute(*journalctl_cmd + ["|", :grep, quote(fetch(:grep_pattern))]) unless fetch(:systemd_services).empty?
+    end
+  end
+
+  desc "Follow the system log output for the applications's systemd service (Ctrl-C to abort)"
+  task :follow do
+    on roles(:app) do
+      execute(*journalctl_cmd + ["-f"]) unless fetch(:systemd_services).empty?
+    end
+  end
+end

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -48,6 +48,9 @@ set :assets_roles, [:web]                                     # this is default
 set :normalize_asset_timestamps, ["public/images", "public/javascripts", "public/stylesheets"]
 set :keep_assets, 2                                           # default: nil (disabled)
 
+# local stuff
+set :systemd_services, ENV.fetch("SYSTEMD_SERVICES", "").split(":")
+
 namespace :caches do
   desc "List caches"
   task :list do
@@ -76,3 +79,4 @@ end
 
 load File.join(File.dirname(__FILE__), "cap", "infrastructure.rb")
 load File.join(File.dirname(__FILE__), "cap", "restart.rb")
+load File.join(File.dirname(__FILE__), "cap", "syslog.rb")

--- a/lib/fauxpaas.rb
+++ b/lib/fauxpaas.rb
@@ -2,6 +2,7 @@
 
 require "fauxpaas/version"
 require "fauxpaas/components"
+
 require "fauxpaas/archive"
 require "fauxpaas/cap"
 require "fauxpaas/cap_runner"
@@ -12,16 +13,17 @@ require "fauxpaas/file_instance_repo"
 require "fauxpaas/filesystem"
 require "fauxpaas/git_reference"
 require "fauxpaas/git_runner"
-require "fauxpaas/infrastructure_archive"
 require "fauxpaas/infrastructure"
+require "fauxpaas/infrastructure_archive"
 require "fauxpaas/instance"
+require "fauxpaas/kernel_system"
 require "fauxpaas/local_git_runner"
 require "fauxpaas/logged_release"
 require "fauxpaas/open3_capture"
 require "fauxpaas/release"
 require "fauxpaas/release_signature"
 require "fauxpaas/remote_git_runner"
-require "fauxpaas/verbose_system_runner"
+require "fauxpaas/verbose_runner"
 
 # Fake Platform As A Service
 module Fauxpaas

--- a/lib/fauxpaas/cap.rb
+++ b/lib/fauxpaas/cap.rb
@@ -49,6 +49,18 @@ module Fauxpaas
       status
     end
 
+    def syslog_view
+      run("syslog:view", {})
+    end
+
+    def syslog_follow
+      run("syslog:follow", {})
+    end
+
+    def syslog_grep(pattern)
+      run("syslog:grep", grep_pattern: pattern)
+    end
+
     private
 
     attr_reader :capfile_path, :stage, :runner, :fs, :common_options

--- a/lib/fauxpaas/cap_runner.rb
+++ b/lib/fauxpaas/cap_runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "fauxpaas/open3_capture"
+require "shellwords"
 
 module Fauxpaas
 
@@ -28,8 +29,9 @@ module Fauxpaas
 
     def capify_options(opts)
       opts.keep_if {|_key, value| value }
-        .map {|key, value| "#{key.to_s.upcase}=#{value}" }
+        .map {|key, value| "#{key.to_s.upcase}=#{Shellwords.escape(value)}" }
     end
+
   end
 
 end

--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -2,6 +2,7 @@
 
 require "thor"
 require "fauxpaas"
+require "fauxpaas/cli/syslog"
 
 module Fauxpaas
   module CLI
@@ -85,6 +86,10 @@ module Fauxpaas
           action: "restart")
       end
 
+      desc "syslog SUBCOMMAND <instance> args...",
+        "Interact with system log contents for the instance"
+      subcommand "syslog", CLI::Syslog
+
       private
 
       attr_reader :instance
@@ -92,7 +97,7 @@ module Fauxpaas
       def setup(instance_name)
         @instance = Fauxpaas.instance_repo.find(instance_name)
         if options.fetch(:verbose, false)
-          Fauxpaas.system_runner = VerboseSystemRunner.new
+          Fauxpaas.system_runner = VerboseRunner.new
         end
       end
 

--- a/lib/fauxpaas/cli/syslog.rb
+++ b/lib/fauxpaas/cli/syslog.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "thor"
+require "fauxpaas"
+
+module Fauxpaas
+  module CLI
+
+    # Main commands of the cli
+    class Syslog < Thor
+
+      desc "view <instance>",
+        "View the system logs for the instance"
+      def view(instance_name)
+        setup(instance_name)
+        instance.interrogator.syslog_view
+      end
+
+      desc "grep <instance> pattern",
+        "View the system logs for the instance"
+      def grep(instance_name, pattern = ".")
+        setup(instance_name)
+        instance.interrogator.syslog_grep(pattern)
+      end
+
+      desc "follow <instance>",
+        "Follow the system logs for the instance"
+      def follow(instance_name)
+        setup(instance_name)
+        instance.interrogator.syslog_follow
+      end
+
+      private
+
+      attr_reader :instance
+
+      def setup(instance_name)
+        @instance = Fauxpaas.instance_repo.find(instance_name)
+        Fauxpaas.system_runner = KernelSystem.new
+      end
+
+    end
+
+  end
+end

--- a/lib/fauxpaas/kernel_system.rb
+++ b/lib/fauxpaas/kernel_system.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Fauxpaas
+
+  # Runner that uses Kernel.system
+  class KernelSystem
+    def run(string)
+      Kernel.system(string)
+    end
+  end
+end

--- a/lib/fauxpaas/verbose_runner.rb
+++ b/lib/fauxpaas/verbose_runner.rb
@@ -5,7 +5,7 @@ require "fauxpaas/open3_capture"
 module Fauxpaas
 
   # Wraps a runner to execute its output verbosely
-  class VerboseSystemRunner
+  class VerboseRunner
     def initialize(runner: Fauxpaas.system_runner)
       @runner = runner
     end

--- a/spec/cap_runner_spec.rb
+++ b/spec/cap_runner_spec.rb
@@ -24,6 +24,20 @@ module Fauxpaas
           zip: "zop"
         })
       end
+
+      it "quotes environment variable values" do
+        expect(kernel).to receive(:run).with(
+          "cap -f #{capfile_path} " + 'myapp-mystage test:task FOO=with\\ spaces ' +
+          'BAR=with\\ double\\"\\ quotes BAZ=\\$horrible\\ \\`arg\\` ' +
+          'QUUX=with\\\\backslash'
+        )
+        runner.run(capfile_path, "myapp-mystage", "test:task", {
+          foo: "with spaces",
+          bar: 'with double" quotes',
+          baz: "$horrible `arg`",
+          quux: "with\\backslash" })
+      end
+
       it "returns stdout, stderr, status" do
         expect(runner.run(capfile_path, "myapp-mystage", "some:task", {}))
           .to eql([stdout, stderr, success])

--- a/spec/cap_spec.rb
+++ b/spec/cap_spec.rb
@@ -144,6 +144,31 @@ module Fauxpaas
       end
     end
 
+    describe "#syslog_view" do
+      subject { cap.syslog_view }
+
+      it_behaves_like "a cap task", "syslog:view"
+    end
+
+    describe "#syslog_follow" do
+      subject { cap.syslog_follow }
+
+      it_behaves_like "a cap task", "syslog:follow"
+    end
+
+    describe "#syslog_grep" do
+      subject { cap.syslog_grep("pattern") }
+
+      it_behaves_like "a cap task", "syslog:grep"
+
+      it "sets :grep_pattern" do
+        expect(backend_runner).to receive(:run)
+          .with(anything, anything, anything, 
+                a_hash_including({grep_pattern: "pattern"}))
+        subject
+      end
+    end
+
     context "when options does not include systemd_services" do
       let(:options) do
         {

--- a/spec/cli/syslog_spec.rb
+++ b/spec/cli/syslog_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "fauxpaas/cli/syslog"
+require_relative "../support/mock_instance.rb"
+
+module Fauxpaas
+  RSpec.describe CLI::Syslog do
+    subject(:cli) { described_class }
+    let(:instance_name) { "something" }
+    include_context "a mock instance"
+
+    let(:mock_cap) { instance_double(Cap) }
+
+    before(:each) do
+      allow(mock_instance).to receive(:interrogator)
+        .and_return(mock_cap)
+    end
+
+    shared_examples_for "a syslog subcommand" do |command|
+      before(:each) { allow(mock_cap).to receive(:"syslog_#{command}") }
+
+      it "runs using a KernelSystem" do
+        cli.start([command, instance_name])
+        expect(Fauxpaas.system_runner).to be_a_kind_of(KernelSystem)
+      end
+
+      it "calls syslog_#{command}" do
+        expect(mock_cap).to receive(:"syslog_#{command}")
+        cli.start([command, instance_name])
+      end
+    end
+
+    describe "#view" do
+      it_behaves_like "a syslog subcommand", "view"
+    end
+
+    describe "#follow" do
+      it_behaves_like "a syslog subcommand", "follow"
+    end
+
+    describe "#grep" do
+      it "calls syslog_grep with the given argument" do
+        expect(mock_cap).to receive(:syslog_grep).with("pattern")
+        cli.start(["grep", instance_name, "pattern"])
+      end
+
+      it_behaves_like "a syslog subcommand", "grep"
+    end
+  end
+end

--- a/spec/support/mock_instance.rb
+++ b/spec/support/mock_instance.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "fauxpaas"
+
+module Fauxpaas
+  RSpec.shared_context "a mock instance" do
+    let(:mock_instance) { instance_double(Instance) }
+
+    let(:mock_instance_repo) do
+      instance_double(FileInstanceRepo,
+        save: true,
+        find: mock_instance)
+    end
+
+    before(:each) do
+      Fauxpaas.instance_repo = mock_instance_repo
+    end
+
+    after(:each) do
+      Fauxpaas.instance_repo = nil
+    end
+  end
+end

--- a/spec/verbose_runner_spec.rb
+++ b/spec/verbose_runner_spec.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
+
 require_relative "./spec_helper"
-require "fauxpaas/verbose_system_runner"
+require "fauxpaas/verbose_runner"
 
 module Fauxpaas
-  RSpec.describe VerboseSystemRunner do
-
+  RSpec.describe VerboseRunner do
     describe "#run" do
       let(:mock_runner) do
         double(:runner,
-               run: ['stdout','stderr',double(:status)])
+          run: ["stdout", "stderr", double(:status)])
       end
 
       let(:command) { "/bin/something" }


### PR DESCRIPTION
Closes AEID-96.

We should be able to use a very similar approach for AEID-95.