### PR TITLE
Decompose components.rb

### DIFF
--- a/lib/fauxpaas/cap.rb
+++ b/lib/fauxpaas/cap.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash/keys"
-require "fauxpaas/components"
+require "fauxpaas/components/token"
 require "fauxpaas/filesystem"
 
 module Fauxpaas

--- a/lib/fauxpaas/components.rb
+++ b/lib/fauxpaas/components.rb
@@ -1,56 +1,6 @@
-# frozen_string_literal: true
-
-require "pathname"
-require "fauxpaas/file_instance_repo"
-require "fauxpaas/open3_capture"
-require "fauxpaas/cap_runner"
-require "fauxpaas/git_runner"
-require "fauxpaas/local_git_resolver"
-require "fauxpaas/remote_git_resolver"
-
-# Fake Platform As A Service
-module Fauxpaas
-
-  class << self
-
-    def root
-      @root ||= Pathname.new(__FILE__).dirname.parent.parent
-    end
-
-    def instance_repo
-      @instance_repo ||= FileInstanceRepo.new(instance_root)
-    end
-
-    def instance_root
-      @instance_root ||= root + "deploy" + "instances"
-    end
-
-    def deployer_env_root
-      @deployer_env_root ||= root + "deploy" + "capfiles"
-    end
-
-    def system_runner
-      @system_runner ||= Open3Capture.new
-    end
-
-    def git_runner
-      @git_runner ||= GitRunner.new(
-        local_resolver: LocalGitResolver.new(system_runner),
-        remote_resolver: RemoteGitResolver.new(system_runner),
-        system_runner: system_runner
-      )
-    end
-
-    def backend_runner
-      @backend_runner ||= CapRunner.new(system_runner)
-    end
-
-    def split_token
-      @split_token ||= File.read(root + ".split_token").chomp.freeze
-    end
-
-    attr_writer :system_runner, :instance_repo, :git_runner
-
-  end
-
-end
+require "fauxpaas/components/backend_runner"
+require "fauxpaas/components/git_runner"
+require "fauxpaas/components/instance_repo"
+require "fauxpaas/components/paths"
+require "fauxpaas/components/system_runner"
+require "fauxpaas/components/token"

--- a/lib/fauxpaas/components/backend_runner.rb
+++ b/lib/fauxpaas/components/backend_runner.rb
@@ -1,0 +1,10 @@
+require "fauxpaas/cap_runner"
+require "fauxpaas/components/system_runner"
+
+module Fauxpaas
+  class << self
+    def backend_runner
+      @backend_runner ||= CapRunner.new(system_runner)
+    end
+  end
+end

--- a/lib/fauxpaas/components/git_runner.rb
+++ b/lib/fauxpaas/components/git_runner.rb
@@ -1,0 +1,18 @@
+require "fauxpaas/components/system_runner"
+require "fauxpaas/git_runner"
+require "fauxpaas/local_git_resolver"
+require "fauxpaas/remote_git_resolver"
+
+module Fauxpaas
+  class << self
+    def git_runner
+      @git_runner ||= GitRunner.new(
+        local_resolver: LocalGitResolver.new(system_runner),
+        remote_resolver: RemoteGitResolver.new(system_runner),
+        system_runner: system_runner
+      )
+    end
+
+    attr_writer :git_runner
+  end
+end

--- a/lib/fauxpaas/components/instance_repo.rb
+++ b/lib/fauxpaas/components/instance_repo.rb
@@ -1,0 +1,11 @@
+require "fauxpaas/file_instance_repo"
+
+module Fauxpaas
+  class << self
+    def instance_repo
+      @instance_repo ||= FileInstanceRepo.new(instance_root)
+    end
+
+    attr_writer :instance_repo
+  end
+end

--- a/lib/fauxpaas/components/paths.rb
+++ b/lib/fauxpaas/components/paths.rb
@@ -1,0 +1,17 @@
+require "pathname"
+
+module Fauxpaas
+  class << self
+    def root
+      @root ||= Pathname.new(__FILE__).dirname.parent.parent.parent
+    end
+
+    def instance_root
+      @instance_root ||= root + "deploy" + "instances"
+    end
+
+    def deployer_env_root
+      @deployer_env_root ||= root + "deploy" + "capfiles"
+    end
+  end
+end

--- a/lib/fauxpaas/components/system_runner.rb
+++ b/lib/fauxpaas/components/system_runner.rb
@@ -1,0 +1,11 @@
+require "fauxpaas/open3_capture"
+
+module Fauxpaas
+  class << self
+    def system_runner
+      @system_runner ||= Open3Capture.new
+    end
+
+    attr_writer :system_runner
+  end
+end

--- a/lib/fauxpaas/components/token.rb
+++ b/lib/fauxpaas/components/token.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "fauxpaas/components/paths"
+
+# Fake Platform As A Service
+module Fauxpaas
+
+  class << self
+    def split_token
+      @split_token ||= File.read(root + ".split_token").chomp.freeze
+    end
+  end
+
+end

--- a/lib/fauxpaas/deploy_config.rb
+++ b/lib/fauxpaas/deploy_config.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require "active_support/core_ext/hash/keys"
-require "fauxpaas/components"
+require "fauxpaas/components/paths"
+require "fauxpaas/components/backend_runner"
 require "fauxpaas/cap"
 
 module Fauxpaas

--- a/lib/fauxpaas/git_reference.rb
+++ b/lib/fauxpaas/git_reference.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "fauxpaas/components/git_runner"
+require "pathname"
+
 module Fauxpaas
 
   # Fully identifies a commit or other reference within a git repository.

--- a/spec/archive_spec.rb
+++ b/spec/archive_spec.rb
@@ -1,7 +1,8 @@
 require_relative "./spec_helper"
 require_relative "./support/spoofed_git_runner"
-require "fauxpaas/components"
+require "fauxpaas/components/git_runner"
 require "fauxpaas/archive"
+require "pathname"
 
 module Fauxpaas
   RSpec.describe Archive do

--- a/spec/cap_spec.rb
+++ b/spec/cap_spec.rb
@@ -1,6 +1,6 @@
 require_relative "./spec_helper"
 require_relative "./support/memory_filesystem"
-require "fauxpaas/components"
+require "fauxpaas/components/token"
 require "fauxpaas/cap"
 
 module Fauxpaas

--- a/spec/cli/main_spec.rb
+++ b/spec/cli/main_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "fauxpaas/cli/main"
+require "fauxpaas/components/system_runner"
+require "fauxpaas/archive"
+require "fauxpaas/git_reference"
 require_relative "../support/mock_instance.rb"
 
 module Fauxpaas

--- a/spec/deploy_config_spec.rb
+++ b/spec/deploy_config_spec.rb
@@ -1,7 +1,6 @@
 require_relative "./spec_helper"
 require "active_support/core_ext/hash/keys"
 require "fauxpaas/deploy_config"
-require "fauxpaas/components"
 
 module Fauxpaas
   RSpec.describe DeployConfig do

--- a/spec/file_instance_repo_spec.rb
+++ b/spec/file_instance_repo_spec.rb
@@ -3,7 +3,7 @@
 require_relative "./spec_helper"
 require_relative "./support/memory_filesystem"
 require_relative "./support/spoofed_git_runner"
-require "fauxpaas/components"
+require "fauxpaas/components/paths"
 require "fauxpaas/file_instance_repo"
 require "yaml"
 

--- a/spec/instance_spec.rb
+++ b/spec/instance_spec.rb
@@ -9,6 +9,7 @@ require "fauxpaas/deploy_archive"
 require "fauxpaas/infrastructure_archive"
 require "fauxpaas/release"
 require "fauxpaas/release_signature"
+require "fauxpaas/components/git_runner"
 require "pathname"
 
 module Fauxpaas


### PR DESCRIPTION
This helps to prevent circular dependencies, and makes the dependencies
on components more clear.