### PR TITLE
Add exec command

### DIFF
--- a/deploy/cap/commands.rb
+++ b/deploy/cap/commands.rb
@@ -1,4 +1,17 @@
 namespace :commands do
+  task :run_one do
+    role = (ENV["FAUX_ROLE"] || :none).to_sym
+    bin = ENV["FAUX_BIN"].to_sym
+    args = ENV["FAUX_ARGS"]
+    on roles(role) do
+      within fetch(:deploy_to) do
+        within 'current' do
+          execute bin, args
+        end
+      end
+    end
+  end
+
   task :run do
     on roles(:all) do |host|
       within fetch(:release_path) do

--- a/lib/fauxpaas/cap.rb
+++ b/lib/fauxpaas/cap.rb
@@ -49,6 +49,17 @@ module Fauxpaas
       status
     end
 
+    # @param role [String] The role on which the command should be run
+    # @param bin [String] The executable
+    # @param args [String] Optional arguments as a single string
+    def exec(role:, bin:, args: "")
+      stdout, stderr, status = run("commands:run_one",
+        faux_bin: bin,
+        faux_args: args,
+        faux_role: role)
+      status
+    end
+
     def syslog_view
       run("syslog:view", {})
     end

--- a/lib/fauxpaas/cli/main.rb
+++ b/lib/fauxpaas/cli/main.rb
@@ -75,6 +75,24 @@ module Fauxpaas
         invoker.add_command(RestartCommand.new(opts))
       end
 
+      desc "exec <instance> <role> <bin> [<args>]",
+        "Run an arbitrary command."
+      long_desc "Run an arbitrary command from the root of the deployed release. " \
+        "The command is only run on hosts that match the supplied role. Legal values " \
+        "for <role> are app, web, db, or all. For best results, quote the full command."
+      def exec(instance_name, role, bin, *args)
+        bin = [bin.split].flatten
+        args = [args.join(" ").split].flatten
+        full = [bin, args].flatten
+        invoker.add_command(
+          ExecCommand.new(opts.merge(
+            role: role,
+            bin: full.first,
+            args: full[1..-1]
+          ))
+        )
+      end
+
       desc "syslog SUBCOMMAND <instance> args...",
         "Interact with system log contents for the instance"
       subcommand "syslog", CLI::Syslog

--- a/lib/fauxpaas/command.rb
+++ b/lib/fauxpaas/command.rb
@@ -172,6 +172,28 @@ module Fauxpaas
     end
   end
 
+  # Run an arbitrary command
+  class ExecCommand < Command
+    def action
+      :exec
+    end
+
+    def extra_keys
+      [:role, :bin, :args]
+    end
+
+    def execute
+      report(instance
+        .interrogator
+        .exec(
+          role: options[:role],
+          bin: options[:bin],
+          args: options[:args].join(" ")
+        )
+      )
+    end
+  end
+
   # View the system logs
   class SyslogViewCommand < Command
     def action

--- a/lib/fauxpaas/policy.rb
+++ b/lib/fauxpaas/policy.rb
@@ -42,13 +42,14 @@ module Fauxpaas
       caches:              :read,
       releases:            :read,
       restart:             :restart,
+      exec:                :deploy,
       syslog_view:         :read,
       syslog_grep:         :read,
       syslog_follow:       :read
     }.freeze
 
     def role?(role)
-      !(roles & IMPLIED_BY[role]).empty?
+      !(roles & IMPLIED_BY.fetch(role, [])).empty?
     end
 
   end

--- a/spec/cap_spec.rb
+++ b/spec/cap_spec.rb
@@ -143,6 +143,24 @@ module Fauxpaas
       end
     end
 
+    describe "#exec" do
+      let(:role) { "app" }
+      let(:bin) { "bundle" }
+      let(:args) { "exec rake db:dostuff" }
+
+      subject { cap.exec(role: role, bin: bin, args: args) }
+
+      it_behaves_like "a cap task", "commands:run_one"
+
+      it "runs the arbitrary command" do
+        expect(backend_runner).to receive(:run)
+          .with(anything, anything, anything, a_hash_including(
+            faux_role: role, faux_bin: bin, faux_args: args
+          ))
+        subject
+      end
+    end
+
     describe "#syslog_view" do
       subject { cap.syslog_view }
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -280,6 +280,41 @@ module Fauxpaas
       end
     end
 
+    describe ExecCommand do
+      let(:command) { described_class.new(options) }
+      let(:options) do
+        {
+          user:          "someone",
+          instance_name: "myapp-mystage",
+          role:          "app",
+          bin:           "bundle",
+          args:          ["exec", "rake", "db:dostuff"]
+        }
+      end
+      it_behaves_like "a command"
+
+      it "action is :exec" do
+        expect(command.action).to eql(:exec)
+      end
+
+      describe "#execute" do
+        let(:instance) do
+          double(:instance,
+            interrogator: double(:interrogator,
+              exec: OpenStruct.new(success?: true)))
+        end
+        it "tells cap to exec" do
+          expect(instance.interrogator).to receive(:exec)
+            .with(
+              role: options[:role],
+              bin: "bundle",
+              args: "exec rake db:dostuff"
+            )
+          command.execute
+        end
+      end
+    end
+
     describe SyslogViewCommand do
       let(:command) { described_class.new(options) }
       let(:options) { { user: "someone", instance_name: "myapp-mystage" } }

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -19,7 +19,7 @@ module Fauxpaas
 
     describe "deploy actions" do
       [
-        :deploy, :rollback
+        :deploy, :rollback, :exec
       ].each do |action|
         include_examples "can perform", "admins", [:admin], action
         include_examples "can perform", "deployers", [:deploy], action


### PR DESCRIPTION
Resolves AEIM-1305
This PR is set to merge to master.

This is primarily to address a need for running intermittent commands
on deployed instances. See AE-3912.

Also includes a fix in `Policy#role?` that would cause an error if an action:roles pair were not defined.