### PR TITLE
Allow group read/write of deployed files and dirs

### DIFF
--- a/deploy/cap/shared.rb
+++ b/deploy/cap/shared.rb
@@ -22,19 +22,20 @@ namespace :shared do
         upload! path.to_s, fetch(:shared_remote_path), recursive: path.directory?
       end
 
-      # Lock down files, except for public. Don't waste time on the bundled gems.
+      # Don't waste time on the bundled gems.
+      # Grant read access to logs until this can be done first-class in fauxpaas
+      execute :mkdir, "-p", "#{fetch(:shared_remote_path)}/log"
+      execute :find, fetch(:shared_remote_path), %W(
+        -path #{fetch(:shared_remote_path)}/public -prune -o
+        -path #{fetch(:shared_remote_path)}/bundle -prune -o
+        -type d
+        -exec chmod 2770 '{}' \\;
+      )
       execute :find, fetch(:shared_remote_path), %W(
         -path #{fetch(:shared_remote_path)}/public -prune -o
         -path #{fetch(:shared_remote_path)}/bundle -prune -o
         -type f
-        -perm /g=rw,o=rw
-        -exec chmod go-rwx '{}' \\;
-      )
-
-      # Grant read access to logs until this can be done first-class in fauxpaas
-      execute :mkdir, "-p", "#{fetch(:shared_remote_path)}/log"
-      execute :find, "#{fetch(:shared_remote_path)}/log", %W(
-        -exec chmod g+r '{}' \\;
+        -exec chmod g+rw,o-rwx '{}' \\;
       )
 
     end

--- a/deploy/cap/unshared.rb
+++ b/deploy/cap/unshared.rb
@@ -14,11 +14,14 @@ namespace :unshared do
         upload! path.to_s, fetch(:release_path), recursive: path.directory?
       end
 
-      # Lock down files, but dont follow symlinks into shared dir
+      # Don't follow symlinks into shared dir
+      execute :find, "-P", fetch(:release_path), %W(
+        -type d
+        -exec chmod 2770 '{}' \\;
+      )
       execute :find, "-P", fetch(:release_path), %W(
         -type f
-        -perm /g=rw,o=rw
-        -exec chmod go-rwx '{}' \\;
+        -exec chmod g+rw,o-rwx '{}' \\;
       )
     end
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -62,28 +62,23 @@ module Fauxpaas
         it "installs unshared files" do
           expect(File.read(current_dir/"some"/"dev"/"file.txt")).to eql("with some dev contents\n")
         end
-        it "sets unshared files to be readable only by the application user" do
+        it "sets unshared files to be readable by the app user+group" do
           file = current_dir/"some"/"dev"/"file.txt"
-          expect(file.world_readable?).to be_falsey
-          expect(file.world_writable?).to be_falsey
+          expect(file.stat.mode & 0777).to eql(0660)
         end
         it "installs shared files" do
           expect(File.read(current_dir/"some"/"shared"/"file.txt"))
             .to eql("with some shared contents\n")
         end
-        it "sets shared files to be readable only by the application user" do
+        it "sets shared files to be readable the app user+group" do
           file = current_dir/"some"/"shared"/"file.txt"
-          expect(file.world_readable?).to be_falsey
-          expect(file.world_writable?).to be_falsey
+          expect(file.stat.mode & 0777).to eql(0660)
         end
         it "sets shared/log to be readable by the application group" do
           dir = current_dir/"log"
           expect(dir.exist?).to be true
           expect(dir.directory?).to be true
-          # We check the group permissions by checking that chmod does nothing
-          before = dir.stat.mode
-          `chmod g+tr #{dir}`
-          expect(dir.stat.mode).to eql(before)
+          expect(dir.stat.mode & 07777).to eql(02770)
         end
         it "runs after_build commands" do
           expect((current_dir/"eureka_2.txt").exist?).to be true


### PR DESCRIPTION
Resolves AEIM-1316

The point here is that the entirety of the deployed directory structure should be fully editable by anyone within the group, and completely locked down otherwise. 

Specifically, I would like someone to confirm that I'm testing for the correct octal permissions.