### PR TITLE
Correctly set permissions on public directories

### DIFF
--- a/deploy/cap/shared.rb
+++ b/deploy/cap/shared.rb
@@ -26,18 +26,21 @@ namespace :shared do
       # Grant read access to logs until this can be done first-class in fauxpaas
       execute :mkdir, "-p", "#{fetch(:shared_remote_path)}/log"
       execute :find, fetch(:shared_remote_path), %W(
+        \\(
         -path #{fetch(:shared_remote_path)}/public -prune -o
-        -path #{fetch(:shared_remote_path)}/bundle -prune -o
-        -type d
+        -path #{fetch(:shared_remote_path)}/bundle -prune
+        \\)
+        -o -type d
         -exec chmod 2770 '{}' \\;
       )
       execute :find, fetch(:shared_remote_path), %W(
+        \\(
         -path #{fetch(:shared_remote_path)}/public -prune -o
-        -path #{fetch(:shared_remote_path)}/bundle -prune -o
-        -type f
+        -path #{fetch(:shared_remote_path)}/bundle -prune
+        \\)
+        -o -type f
         -exec chmod g+rw,o-rwx '{}' \\;
       )
-
     end
   end
 

--- a/deploy/cap/unshared.rb
+++ b/deploy/cap/unshared.rb
@@ -16,11 +16,13 @@ namespace :unshared do
 
       # Don't follow symlinks into shared dir
       execute :find, "-P", fetch(:release_path), %W(
-        -type d
+        -path #{fetch(:release_path)}/public -prune
+        -o -type d
         -exec chmod 2770 '{}' \\;
       )
       execute :find, "-P", fetch(:release_path), %W(
-        -type f
+        -path #{fetch(:release_path)}/public -prune
+        -o -type f
         -exec chmod g+rw,o-rwx '{}' \\;
       )
     end

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -71,6 +71,36 @@ namespace :caches do
   end
 end
 
+task :open_public do
+  on roles(:all) do
+    set :shared_path, File.join(fetch(:deploy_to), "shared")
+    set :releases_path, File.join(fetch(:deploy_to), "releases")
+    execute :mkdir, "-p", "#{fetch(:shared_path)}/public"
+    execute :mkdir, "-p", "#{fetch(:release_path)}/public"
+    execute :chmod, "2775", fetch(:shared_path)
+    execute :chmod, "2775", fetch(:releases_path)
+    execute :chmod, "2775", fetch(:release_path)
+    execute :find, "#{fetch(:shared_path)}/public", %W(
+      -type d
+      -exec chmod 2775 '{}' \\;
+    )
+    execute :find, "#{fetch(:shared_path)}/public", %W(
+      -type f
+      -exec chmod 664 '{}' \\;
+    )
+    execute :find, "#{fetch(:release_path)}/public", %W(
+      -type d
+      -exec chmod 2775 '{}' \\;
+    )
+    execute :find, "#{fetch(:release_path)}/public", %W(
+      -type f
+      -exec chmod 664 '{}' \\;
+    )
+  end
+end
+
+after "deploy:updated", :open_public
+
 load File.join(File.dirname(__FILE__), "cap", "shared.rb")
 load File.join(File.dirname(__FILE__), "cap", "unshared.rb")
 load File.join(File.dirname(__FILE__), "cap", "restart.rb")


### PR DESCRIPTION
See AEIM-1318

* Adds several integration tests for proper permissions
* Fixes find-powered chmods in shared.rb, unshared.rb
* Sets permissions on public files at the end of the build, in deploy.rb

---

This PR required changes to the fixtures, which must be `git pull`'d in order to run the integration tests. The unit tests are unaffected.