### PR TITLE
Download source directly instead of via capistrano

### DIFF
--- a/deploy/cap/source.rb
+++ b/deploy/cap/source.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "pathname"
+
+namespace :source do
+  task :setup do
+    set :source_local_path, ENV["SOURCE_PATH"]
+  end
+
+  desc "Upload source"
+  task upload: [:setup] do
+    on roles(:all) do
+      Pathname.new(fetch(:source_local_path)).children.each do |path|
+        upload! path.to_s, fetch(:release_path), recursive: path.directory?
+      end
+
+      # We refrain from chmoding the files here because unshared:upload
+      # will do it for us.
+    end
+  end
+end
+
+before "deploy:updating", "source:upload"

--- a/deploy/capfiles/norails.capfile
+++ b/deploy/capfiles/norails.capfile
@@ -9,8 +9,8 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 # Load the SCM plugin appropriate to your project:
-require "capistrano/scm/git"
-install_plugin Capistrano::SCM::Git
+require "fauxpaas/dir_only_scm"
+install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"

--- a/deploy/capfiles/rails.capfile
+++ b/deploy/capfiles/rails.capfile
@@ -9,8 +9,8 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 # Load the SCM plugin appropriate to your project:
-require "capistrano/scm/git"
-install_plugin Capistrano::SCM::Git
+require "fauxpaas/dir_only_scm"
+install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -2,8 +2,6 @@
 
 lock "~> 3.9.1"
 
-set :repo_url, ENV["SOURCE_REPO"]
-set :branch, ENV["BRANCH"]
 set :deploy_to, ENV["DEPLOY_DIR"] || fetch(:deploy_to)
 set :rails_env, ENV["RAILS_ENV"]
 set :assets_prefix, ENV["ASSETS_PREFIX"]
@@ -102,6 +100,7 @@ end
 after "deploy:updated", :open_public
 
 load File.join(File.dirname(__FILE__), "cap", "shared.rb")
+load File.join(File.dirname(__FILE__), "cap", "source.rb")
 load File.join(File.dirname(__FILE__), "cap", "unshared.rb")
 load File.join(File.dirname(__FILE__), "cap", "restart.rb")
 load File.join(File.dirname(__FILE__), "cap", "syslog.rb")

--- a/lib/fauxpaas/cap.rb
+++ b/lib/fauxpaas/cap.rb
@@ -13,15 +13,14 @@ module Fauxpaas
       @runner = runner
     end
 
-    # @param source [ArchiveReference]
+    # @param source_path [Pathname]
     # @param shared_path [Pathname]
     # @param unshared_path [Pathname]
-    def deploy(source, shared_path, unshared_path)
+    def deploy(source_path, shared_path, unshared_path)
       _, _, status = run("deploy",
+        source_path: source_path.to_s,
         shared_config_path: shared_path.to_s,
-        unshared_config_path: unshared_path.to_s,
-        source_repo: source.url,
-        branch: source.commitish.to_s)
+        unshared_config_path: unshared_path.to_s)
       status
     end
 

--- a/lib/fauxpaas/dir_only_scm.rb
+++ b/lib/fauxpaas/dir_only_scm.rb
@@ -1,15 +1,14 @@
+# frozen_string_literal: true
+
 require "capistrano/scm/plugin"
-require "pathname"
+require "fileutils"
 
 module Fauxpaas
-  # A capistrano source control manager that uses standard file copy.
-  # Only works locally.
-  class CopySCM < ::Capistrano::SCM::Plugin
+  # A capistrano source control manager that does nothing.
+  # It's only purpose is to disable the SCM.
+  class DirOnlySCM < ::Capistrano::SCM::Plugin
 
-    # Define any variables needed to configure the plugin.
-    # set_if_empty :myvar, "some_value"
-    def set_defaults
-    end
+    def set_defaults; end
 
     # This must define a task (called create_release) by convention
     # that creates the release directory and copies the source code
@@ -19,9 +18,6 @@ module Fauxpaas
         task :create_release do
           on release_roles(:all) do
             FileUtils.mkdir_p release_path
-            Pathname.new(repo_url).children.each do |path|
-              FileUtils.cp_r path, release_path
-            end
           end
         end
         task :set_current_revision do

--- a/lib/fauxpaas/release.rb
+++ b/lib/fauxpaas/release.rb
@@ -7,12 +7,12 @@ module Fauxpaas
   class Release
 
     # @param deploy_config [DeployConfig]
-    # @param source [ArchiveReference]
+    # @param source_path [Pathname]
     # @param shared_path [Pathname]
     # @param unshared_path [Pathname]
-    def initialize(deploy_config:, source:, shared_path:, unshared_path:)
+    def initialize(deploy_config:, source_path:, shared_path:, unshared_path:)
       @deploy_config = deploy_config
-      @source = source
+      @source_path = source_path
       @shared_path = shared_path
       @unshared_path = unshared_path
     end
@@ -20,18 +20,18 @@ module Fauxpaas
     def deploy
       deploy_config
         .runner
-        .deploy(source, shared_path, unshared_path)
+        .deploy(source_path, shared_path, unshared_path)
     end
 
     def eql?(other)
-      [:@shared_path, :@unshared, :@source, :@deploy_config].index do |var|
+      [:@shared_path, :@unshared, :@source_path, :@deploy_config].index do |var|
         instance_variable_get(var) != other.instance_variable_get(var)
       end.nil?
     end
 
     private
 
-    attr_reader :shared_path, :unshared_path, :source
+    attr_reader :shared_path, :unshared_path, :source_path
     attr_reader :deploy_config
 
   end

--- a/lib/fauxpaas/release_builder.rb
+++ b/lib/fauxpaas/release_builder.rb
@@ -22,7 +22,7 @@ module Fauxpaas
         shared_path: extract_ref(signature.shared, dir/"shared"),
         unshared_path: extract_ref(signature.unshared, dir/"unshared"),
         deploy_config: deploy_config(signature),
-        source: signature.source
+        source_path: extract_ref(signature.source, dir/"source")
       )
     end
 

--- a/spec/cap_spec.rb
+++ b/spec/cap_spec.rb
@@ -68,10 +68,10 @@ module Fauxpaas
     end
 
     describe "#deploy" do
+      let(:source_path) { Pathname.new("some/path/source") }
       let(:shared_path) { Pathname.new("some/path/shared") }
       let(:unshared_path) { Pathname.new("some/path/unshared") }
-      let(:source) { double(:source, url: "someurl", commitish: "someref") }
-      subject { cap.deploy(source, shared_path, unshared_path) }
+      subject { cap.deploy(source_path, shared_path, unshared_path) }
 
       it_behaves_like "a cap task", "deploy"
 

--- a/spec/fixtures/integration/capfiles/norails.capfile
+++ b/spec/fixtures/integration/capfiles/norails.capfile
@@ -9,8 +9,8 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 # Load the SCM plugin appropriate to your project:
-require "fauxpaas/copy_scm"
-install_plugin Fauxpaas::CopySCM
+require "fauxpaas/dir_only_scm"
+install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"

--- a/spec/fixtures/integration/capfiles/rails.capfile
+++ b/spec/fixtures/integration/capfiles/rails.capfile
@@ -9,8 +9,8 @@ require "capistrano/setup"
 require "capistrano/deploy"
 
 # Load the SCM plugin appropriate to your project:
-require "fauxpaas/copy_scm"
-install_plugin Fauxpaas::CopySCM
+require "fauxpaas/dir_only_scm"
+install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"

--- a/spec/release_builder_spec.rb
+++ b/spec/release_builder_spec.rb
@@ -48,6 +48,8 @@ module Fauxpaas
     let(:builder) { described_class.new(fs) }
 
     before(:each) do
+      allow(source).to receive(:checkout)
+        .and_yield(FakeWorkingDir.new(fs.tmpdir, [Pathname.new("some_source.rb")]))
       allow(unshared).to receive(:checkout)
         .and_yield(FakeWorkingDir.new(fs.tmpdir, [Pathname.new("unshared.yml")]))
       allow(shared).to receive(:checkout)
@@ -71,7 +73,7 @@ module Fauxpaas
           release = builder.build(signature)
           expect(release).to eql(
             Release.new(
-              source: signature.source,
+              source_path: fs.tmpdir/"source",
               shared_path: fs.tmpdir/"shared",
               unshared_path: fs.tmpdir/"unshared",
               deploy_config: DeployConfig.from_hash(deploy_content)

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -10,13 +10,7 @@ module Fauxpaas
   RSpec.describe Release do
     let(:success) { double(:success, success?: true) }
     let(:runner) { double(:runner, run: [nil, nil, success]) }
-    let(:source) do
-      ArchiveReference.new(
-        "source.git",
-        "1238019283019823019823091832",
-        Fauxpaas.git_runner
-      )
-    end
+    let(:source_path) { Pathname.new("/tmp/source") }
     let(:shared_path) { Pathname.new("/tmp/shared/structure") }
     let(:unshared_path) { Pathname.new("/tmp/unshared/structure") }
     let(:deploy_config) do
@@ -36,7 +30,7 @@ module Fauxpaas
         deploy_config: deploy_config,
         shared_path: shared_path,
         unshared_path: unshared_path,
-        source: source
+        source_path: source_path
       )
     end
 
@@ -53,7 +47,7 @@ module Fauxpaas
       end
       it "calls deploy with the source" do
         expect(runner).to receive(:deploy)
-          .with(source, anything, anything)
+          .with(source_path, anything, anything)
         release.deploy
       end
     end


### PR DESCRIPTION
Resolves AEIM-1354

* Cap uses source_path instead of source
* Release uses source_path instead of source
* ReleaseBuilder uses source_path instead of source
* Add source upload to cap w/o scm
* Capfiles no longer download source with an SCM
* Remove now-unused CopySCM