### PR TITLE
AEIM-1518 - Fix failing temp file tests

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -11,7 +11,7 @@ module Fauxpaas
     describe "deploy" do
       RSpec.shared_context "deploy setup" do |instance_name|
         before(:all) do
-          @root = Pathname.new(Dir.tmpdir)/"fauxpaas"/"sandbox"/instance_name
+          @root = Pathname.new(File.realpath(Dir.tmpdir))/"fauxpaas"/"sandbox"/instance_name
           `mkdir -p #{@root}`
           Fauxpaas.reset!
           Fauxpaas.initialize!


### PR DESCRIPTION
There were some spots where tests made assumptions about /tmp that don't
hold on OSX because of the symlinks at the filesystem root. This change
uses Dir.mktmpdir and File.realpath to use a system-specified temp
directory and resolve the paths fully for comparison in the assertions.