### PR TITLE
AEIM-1363 - Run bundle install after adding references

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,35 @@ Set the environment variable `DEBUG` to `true` to see verbose output.
 When you create a PR, code climate will yell at you. Rubocop is built into repo, and can be
 run with `bundle exec rubocop`. Try `--help`
 
+### Running integration on a Mac
+
+You need SSHD running, and you need a particular key file. You also need
+a symlink to rbenv. Replace references to mattlach with your own stuff.
+
+    $ sudo systemsetup -setremotelogin on
+    $ ssh-keygen
+    Generating public/private rsa key pair.
+    Enter file in which to save the key: /Users/mattlach/.ssh/id_rsa-fauxpaas
+    Enter passphrase (empty for no passphrase):
+    Enter same passphrase again:
+    Your identification has been saved in id_rsa-fauxpaas.
+    Your public key has been saved in id_rsa-fauxpaas.pub.
+    The key fingerprint is:
+    The key's randomart image is:
+    +---[RSA 2048]----+
+    |                 |
+    |                 |
+    | .  .            |
+    |o. . .           |
+    |=oo . . S        |
+    |+=.o . .         |
+    |X.+ =..          |
+    |BE.Oo+.          |
+    |%%^B=..          |
+    +----[SHA256]-----+
+    $ cat ~/id_rsa-fauxpaas.pub >> ~/authorized_keys
+    $ mkdir ~/.rbenv/bin
+    $ ln -s /usr/local/bin/rbenv ~/.rbenv/bin/rbenv
 
 ## Named Instance
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     fauxpaas (0.2.0)
       canister
       capistrano (~> 3.9.1)
-      capistrano-bundler
       capistrano-rails
       capistrano-rbenv
       ettin (~> 1.1.0)
@@ -108,4 +107,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/deploy/capfiles/norails.capfile
+++ b/deploy/capfiles/norails.capfile
@@ -14,5 +14,3 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
-

--- a/deploy/capfiles/rails.capfile
+++ b/deploy/capfiles/rails.capfile
@@ -14,7 +14,6 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
 require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -18,20 +18,14 @@ set :keep_releases, 5
 set :local_user, "faux"
 set :pty, false
 
-# Configure capistrano-bundler
-set :bundle_roles, :all                                         # this is default
-set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
-set :bundle_path, -> { shared_path.join("bundle") }             # this is default
-set :bundle_without, (["development", "test"] - [ENV["RAILS_ENV"]]).join(" ")
-set :bundle_flags, "--deployment"
-set :bundle_env_variables, {}                                   # this is default
-set :bundle_clean_options, ""                                   # this is default
-set :bundle_jobs, 4                                             # default: nil
+# We only link files that would be non-sensical to be release-specific.
+# This notably does not contain developer configuration.
+append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
 
 # Configure capistrano-rbenv
 # intentionally omit setting :rbenv_ruby
 set :rbenv_type, :system
-set :rbenv_map_bins, ["rake", "gem", "bundle", "ruby", "rails", "pry"]
+set :rbenv_map_bins, ["rake", "gem", "ruby", "rails", "pry"]
 set :rbenv_custom_path, ENV["RBENV_ROOT"]
 set :rbenv_prefix, lambda {
   "RBENV_ROOT=#{fetch(:rbenv_path)} RBENV_VERSION=#{fetch(:rbenv_ruby)} " \

--- a/fauxpaas.gemspec
+++ b/fauxpaas.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "capistrano", "~> 3.9.1"
-  spec.add_runtime_dependency "capistrano-bundler"
   spec.add_runtime_dependency "capistrano-rails"
   spec.add_runtime_dependency "capistrano-rbenv"
   spec.add_runtime_dependency "canister"

--- a/spec/fixtures/integration/capfiles/norails.capfile
+++ b/spec/fixtures/integration/capfiles/norails.capfile
@@ -14,5 +14,3 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
-

--- a/spec/fixtures/integration/capfiles/rails.capfile
+++ b/spec/fixtures/integration/capfiles/rails.capfile
@@ -14,7 +14,6 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
 require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 

--- a/spec/fixtures/integration/repos/norails/source/Gemfile
+++ b/spec/fixtures/integration/repos/norails/source/Gemfile
@@ -3,3 +3,11 @@
 source "https://rubygems.org"
 
 gem "pry"
+
+group :development do
+  gem "faker"
+end
+
+group :test do
+  gem "rspec"
+end

--- a/spec/fixtures/integration/repos/norails/source/Gemfile.lock
+++ b/spec/fixtures/integration/repos/norails/source/Gemfile.lock
@@ -2,16 +2,37 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.3)
+    faker (1.9.1)
+      i18n (>= 0.7)
+    i18n (1.1.0)
+      concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  faker
   pry
+  rspec
 
 BUNDLED WITH
-   1.16.0
+   1.16.4


### PR DESCRIPTION
This doesn't do anything with caching because bundler does that automatically as long as it's set up with a cache on the build server—so that's more a job for puppet. Unless anyone thinks there's a case for fauxpaas to know details about how the build server is set up as a whole?

Also I'm not sure if I was right to add an exception in the case of a bundle error. If we have other sanity checks that make the exception redundant, then I should definitely remove it.