### PR TITLE
Create ArtifactBuilder

### DIFF
--- a/lib/fauxpaas.rb
+++ b/lib/fauxpaas.rb
@@ -3,6 +3,7 @@
 require "fauxpaas/version"
 require "fauxpaas/archive_reference"
 require "fauxpaas/artifact"
+require "fauxpaas/artifact_builder"
 require "fauxpaas/auth_service"
 require "fauxpaas/cap"
 require "fauxpaas/cap_runner"
@@ -92,6 +93,12 @@ module Fauxpaas
           Fauxpaas::ReferenceRepo.new(
             c.ref_root,
             c.git_runner
+          )
+        end
+        container.register(:artifact_builder) do |c|
+          Fauxpaas::ArtifactBuilder.new(
+            ref_repo: c.ref_repo,
+            factory: Artifact
           )
         end
         container.register(:instance_repo) do |c|

--- a/lib/fauxpaas/artifact.rb
+++ b/lib/fauxpaas/artifact.rb
@@ -5,27 +5,11 @@ module Fauxpaas
   # application server. Pending work on AEIM-1361, AEIM-1362,
   # AEIM-1375, AEIM-1363, etc to fully expose the proper shape of this.
   class Artifact
-    def initialize(signature:, ref_repo:)
-      @path = Pathname.new(Dir.mktmpdir)
-      @ref_repo = ref_repo
-
-      # to extract to builder
-      add_reference(signature.shared)
-      add_reference(signature.unshared)
-      add_reference(signature.source)
+    def initialize(path)
+      @path = path
     end
 
     attr_reader :path
-
-    private
-
-    attr_reader :ref_repo
-
-    def add_reference(ref)
-      ref_repo.resolve(ref)
-        .cp(path)
-        .write
-    end
-
   end
+
 end

--- a/lib/fauxpaas/artifact_builder.rb
+++ b/lib/fauxpaas/artifact_builder.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "fauxpaas/artifact"
+require "pathname"
+
+module Fauxpaas
+
+  # Builds artifacts
+  # @see Artifact
+  class ArtifactBuilder
+    def initialize(ref_repo:, factory:)
+      @ref_repo = ref_repo
+      @factory = factory
+    end
+
+    # Build an artifact in the system's temporary directory
+    # @param signature [ReleaseSignature]
+    # @return The result of factory.new, pointing at the path
+    def build(signature)
+      path = Pathname.new(Dir.mktmpdir)
+      add_references!(signature, path)
+      factory.new(path)
+    end
+
+    private
+
+    attr_reader :ref_repo, :factory
+
+    def add_references!(signature, path)
+      [signature.source, signature.shared, signature.unshared].each do |ref|
+        add_reference(ref, path)
+      end
+    end
+
+    def add_reference(ref, path)
+      ref_repo.resolve(ref)
+        .cp(path)
+        .write
+    end
+
+  end
+end

--- a/lib/fauxpaas/command.rb
+++ b/lib/fauxpaas/command.rb
@@ -61,7 +61,7 @@ module Fauxpaas
       signature = instance.signature(reference)
 
       release = Release.new(
-        artifact: Artifact.new(signature: signature, ref_repo: Fauxpaas.ref_repo),
+        artifact: Fauxpaas.artifact_builder.build(signature),
         deploy_config: DeployConfig.from_ref(signature.deploy, Fauxpaas.ref_repo)
       )
       status = release.deploy

--- a/spec/artifact_builder_spec.rb
+++ b/spec/artifact_builder_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "fauxpaas/artifact_builder"
+require "pathname"
+
+module Fauxpaas
+  class FakeLazyDir
+    attr_reader :path
+    def initialize(path)
+      @path = path
+    end
+
+    def cp(base)
+      self.class.new(base)
+    end
+
+    def write
+      self
+    end
+  end
+
+  class TestArtifact
+    attr_reader :path
+    def initialize(path)
+      @path = path
+    end
+  end
+
+  # require "fauxpaas/artifact_builder"
+  RSpec.describe ArtifactBuilder do
+    let(:ref_repo) { double(:ref_repo) }
+    let(:builder) { described_class.new(ref_repo: ref_repo) }
+    let(:builder) do
+      described_class.new(
+        ref_repo: ref_repo,
+        factory: TestArtifact
+      )
+    end
+
+    describe "#build" do
+      let(:tmpdir) { Pathname.new "/tmp/dir" }
+      let(:source) { double(:source) }
+      let(:shared) { double(:shared) }
+      let(:deploy) { double(:deploy) }
+      let(:unshared) { double(:unshared) }
+      let(:signature) { double(:signature, shared: shared, unshared: unshared, source: source) }
+
+      before(:each) do
+        allow(Dir).to receive(:mktmpdir).and_return(tmpdir.to_s)
+        allow(ref_repo).to receive(:resolve).with(source)
+          .and_return(FakeLazyDir.new("/some_source"))
+        allow(ref_repo).to receive(:resolve).with(shared)
+          .and_return(FakeLazyDir.new("/some_shared"))
+        allow(ref_repo).to receive(:resolve).with(unshared)
+          .and_return(FakeLazyDir.new("/some_unshared"))
+      end
+
+      it "constructs artifacts" do
+        expect(builder.build(signature)).not_to be_nil
+      end
+
+      it "returns the temporary directory with the artifacts" do
+        expect(builder.build(signature).path).to eq(tmpdir)
+      end
+
+      [:source, :shared, :unshared].each do |attr|
+        it "resolves the #{attr} repository" do
+          expect(ref_repo).to receive(:resolve).with(send(attr))
+            .and_return(FakeLazyDir.new("/some_#{attr}"))
+
+          builder.build(signature)
+        end
+      end
+    end
+  end
+end

--- a/spec/artifact_spec.rb
+++ b/spec/artifact_spec.rb
@@ -5,55 +5,13 @@ require "fauxpaas/artifact"
 require "pathname"
 
 module Fauxpaas
-  class FakeLazyDir
-    attr_reader :path
-    def initialize(path)
-      @path = path
-    end
-
-    def cp(base)
-      self.class.new(base)
-    end
-
-    def write
-      self
-    end
-  end
-
   RSpec.describe Artifact do
-    let(:ref_repo) { double(:ref_repo) }
-    let(:tmpdir) { Pathname.new "/tmp/dir" }
-    let(:source) { double(:source) }
-    let(:shared) { double(:shared) }
-    let(:deploy) { double(:deploy) }
-    let(:unshared) { double(:unshared) }
+    let(:path) { Pathname.new("/some/path") }
+    let(:artifact) { described_class.new(path) }
 
-    before(:each) do
-      allow(Dir).to receive(:mktmpdir).and_return(tmpdir.to_s)
-      allow(ref_repo).to receive(:resolve).with(source).and_return(FakeLazyDir.new("/some_source"))
-      allow(ref_repo).to receive(:resolve).with(shared).and_return(FakeLazyDir.new("/some_shared"))
-      allow(ref_repo).to receive(:resolve).with(unshared)
-        .and_return(FakeLazyDir.new("/some_unshared"))
-    end
-
-    let(:signature) { double(:signature, shared: shared, unshared: unshared, source: source) }
-
-    let(:artifact) { described_class.new(signature: signature, ref_repo: ref_repo) }
-
-    it "can be constructed" do
-      expect(artifact).not_to be_nil
-    end
-
-    it "returns the temporary directory with the artifacts" do
-      expect(artifact.path).to eq(tmpdir)
-    end
-
-    [:source, :shared, :unshared].each do |attr|
-      it "resolves the #{attr} repository" do
-        expect(ref_repo).to receive(:resolve).with(send(attr))
-          .and_return(FakeLazyDir.new("/some_#{attr}"))
-
-        artifact
+    describe "#path" do
+      it "has a path" do
+        expect(artifact.path).to eql(path)
       end
     end
   end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -88,10 +88,10 @@ module Fauxpaas
           )
         end
         before(:each) do
+          allow(Fauxpaas.artifact_builder).to receive(:build).with(signature)
+            .and_return(artifact)
           allow(DeployConfig).to receive(:from_ref).with(signature.deploy, Fauxpaas.ref_repo)
             .and_return(deploy_config)
-          allow(Artifact).to receive(:new).with(signature: signature, ref_repo: Fauxpaas.ref_repo)
-            .and_return(artifact)
           allow(Release).to receive(:new).with(artifact: artifact, deploy_config: deploy_config)
             .and_return(release)
         end


### PR DESCRIPTION
Moves the work done in `Artifact#initialize` to `ArtifactBuilder`, and registers the builder to the canister in `fauxpaas.rb`.