### PR TITLE
WIP: AEIM-1365: asset precompilation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     rainbow (3.0.0)
-    rake (10.5.0)
+    rake (12.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -100,10 +100,10 @@ DEPENDENCIES
   fakefs
   fauxpaas!
   pry
-  rake (~> 10.0)
+  rake
   rspec (~> 3.0)
   rubocop
   simplecov
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/deploy/capfiles/norails.capfile
+++ b/deploy/capfiles/norails.capfile
@@ -14,5 +14,4 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
 

--- a/deploy/capfiles/rails.capfile
+++ b/deploy/capfiles/rails.capfile
@@ -15,6 +15,4 @@ install_plugin Fauxpaas::DirOnlySCM
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
 require "capistrano/bundler"
-require "capistrano/rails/assets"
-require "capistrano/rails/migrations"
 

--- a/deploy/capfiles/rails.capfile
+++ b/deploy/capfiles/rails.capfile
@@ -14,5 +14,4 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
 

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -22,16 +22,6 @@ set :pty, false
 # This notably does not contain developer configuration.
 append :linked_dirs, "bundle", "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"
 
-# Configure capistrano-bundler
-set :bundle_roles, :all                                         # this is default
-set :bundle_servers, -> { release_roles(fetch(:bundle_roles)) } # this is default
-set :bundle_path, -> { shared_path.join("bundle") }             # this is default
-set :bundle_without, (["development", "test"] - [ENV["RAILS_ENV"]]).join(" ")
-set :bundle_flags, "--deployment"
-set :bundle_env_variables, {}                                   # this is default
-set :bundle_clean_options, ""                                   # this is default
-set :bundle_jobs, 4                                             # default: nil
-
 # Configure capistrano-rbenv
 # intentionally omit setting :rbenv_ruby
 set :rbenv_type, :system

--- a/fauxpaas.gemspec
+++ b/fauxpaas.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "fakefs"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"

--- a/lib/fauxpaas/artifact.rb
+++ b/lib/fauxpaas/artifact.rb
@@ -5,7 +5,7 @@ module Fauxpaas
   # application server. Pending work on AEIM-1361, AEIM-1362,
   # AEIM-1375, AEIM-1363, etc to fully expose the proper shape of this.
   class Artifact
-    def initialize(path)
+    def initialize(path = Pathname.new(Dir.mktmpdir))
       @path = path
     end
 

--- a/lib/fauxpaas/artifact_builder.rb
+++ b/lib/fauxpaas/artifact_builder.rb
@@ -2,7 +2,6 @@
 
 require "fauxpaas/artifact"
 require "pathname"
-require "pry"
 
 module Fauxpaas
 
@@ -22,10 +21,9 @@ module Fauxpaas
 
       add_references!(signature)
       run_command("/usr/bin/env")
-      run_command("bundle install --deployment --without development test --path vendor/bundle")
+      # run_command("bundle install --deployment --without development test --path vendor/bundle")
+      run_command("bundle install")
       run_command("bundle exec rake assets:precompile RAILS_ENV=production")
-
-      binding.pry
 
       @artifact
     end
@@ -38,7 +36,7 @@ module Fauxpaas
 
     def add_references!(signature)
       [signature.source, signature.shared, signature.unshared].each do |ref|
-        merge_path(ref_repo.resolve(ref),artifact.path)
+        merge_path(ref_repo.resolve(ref), artifact.path)
       end
     end
 
@@ -50,7 +48,7 @@ module Fauxpaas
       end
     end
 
-    def merge_path(source,dst)
+    def merge_path(source, dst)
       source
         .cp(dst)
         .write

--- a/lib/fauxpaas/command.rb
+++ b/lib/fauxpaas/command.rb
@@ -59,12 +59,7 @@ module Fauxpaas
 
     def execute
       signature = instance.signature(reference)
-
-      release = Release.new(
-        artifact: Fauxpaas.artifact_builder.build(signature),
-        deploy_config: DeployConfig.from_ref(signature.deploy, Fauxpaas.ref_repo)
-      )
-      status = release.deploy
+      status = Release.new(signature).deploy
       report(status, action: "deploy")
 
       if status.success?
@@ -147,7 +142,7 @@ module Fauxpaas
 
     def execute
       string = if long
-        LoggedReleases.new(instance.releases).to_s
+                 LoggedReleases.new(instance.releases).to_s
       else
         LoggedReleases.new(instance.releases).to_short_s
       end
@@ -192,8 +187,7 @@ module Fauxpaas
           role: role,
           bin: bin,
           args: args.join(" ")
-        )
-      )
+        ))
     end
   end
 

--- a/lib/fauxpaas/release.rb
+++ b/lib/fauxpaas/release.rb
@@ -8,11 +8,17 @@ module Fauxpaas
   # operations first create a release, and then attempt to deploy it.
   class Release
 
-    # @param artifact [Artifact]
-    # @param deploy_config [DeployConfig]
-    def initialize(artifact:, deploy_config:)
-      @artifact = artifact
-      @deploy_config = deploy_config
+    # @param signature [ReleaseSignature]
+    def initialize(signature)
+      @signature = signature
+    end
+
+    def deploy_config
+      @deploy_config ||= DeployConfig.from_ref(signature.deploy, Fauxpaas.ref_repo)
+    end
+
+    def artifact
+      @artifact ||= Fauxpaas.artifact_builder.build(signature)
     end
 
     def deploy
@@ -23,7 +29,7 @@ module Fauxpaas
 
     private
 
-    attr_reader :artifact, :deploy_config
+    attr_reader :signature
 
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -70,9 +70,7 @@ module Fauxpaas
 
       describe "#execute" do
         let(:release) { double(:release, deploy: status) }
-        let(:artifact) { double(:artifact) }
-        let(:deploy_config) { double(:deploy_config) }
-        let(:signature) { double(:signature, deploy: double(:deploy_ref)) }
+        let(:signature) { double(:signature) }
         let(:instance) do
           double(
             :instance,
@@ -88,11 +86,7 @@ module Fauxpaas
           )
         end
         before(:each) do
-          allow(Fauxpaas.artifact_builder).to receive(:build).with(signature)
-            .and_return(artifact)
-          allow(DeployConfig).to receive(:from_ref).with(signature.deploy, Fauxpaas.ref_repo)
-            .and_return(deploy_config)
-          allow(Release).to receive(:new).with(artifact: artifact, deploy_config: deploy_config)
+          allow(Release).to receive(:new).with(signature)
             .and_return(release)
         end
         context "when it succeeds" do

--- a/spec/fixtures/integration/capfiles/norails.capfile
+++ b/spec/fixtures/integration/capfiles/norails.capfile
@@ -14,5 +14,4 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"
 

--- a/spec/fixtures/integration/capfiles/rails.capfile
+++ b/spec/fixtures/integration/capfiles/rails.capfile
@@ -14,4 +14,3 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
-require "capistrano/bundler"

--- a/spec/fixtures/integration/capfiles/rails.capfile
+++ b/spec/fixtures/integration/capfiles/rails.capfile
@@ -15,6 +15,3 @@ install_plugin Fauxpaas::DirOnlySCM
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
 require "capistrano/bundler"
-require "capistrano/rails/assets"
-require "capistrano/rails/migrations"
-

--- a/spec/fixtures/integration/repos/rails/source/Gemfile.lock
+++ b/spec/fixtures/integration/repos/rails/source/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)

--- a/spec/fixtures/integration/repos/rails/unshared/after_build.yml
+++ b/spec/fixtures/integration/repos/rails/unshared/after_build.yml
@@ -10,3 +10,7 @@
     - app
   bin: touch
   opts: "eureka_2.txt"
+- roles:
+    - app
+  bin: rake
+  opts: "bundle exec db:migrate RAILS_ENV=production"

--- a/spec/fixtures/integration/repos/rails/unshared/after_build.yml
+++ b/spec/fixtures/integration/repos/rails/unshared/after_build.yml
@@ -13,4 +13,4 @@
 - roles:
     - app
   bin: rake
-  opts: "bundle exec db:migrate RAILS_ENV=production"
+  opts: "db:migrate RAILS_ENV=production"

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -135,7 +135,7 @@ module Fauxpaas
         end
       end
 
-      xcontext "without rails" do
+      context "without rails" do
         include_context "deploy setup", "test-norails"
         let(:gem) { "pry" }
         let(:source) { Pathname.new("some_source_file.txt") }
@@ -155,7 +155,9 @@ module Fauxpaas
         end
 
         it "precompiles the assets" do
-          expect(current_dir/"public"/"assets".entries.map { |p| p.to_s }).to contain(a_string_matching(/^application-.*.css.gz$/), a_string_matching(/^application-.*.js.gz$/))
+          expect((current_dir/"public"/"assets").entries.map(&:to_s))
+            .to include(a_string_matching(/^application-.*.css.gz$/),
+              a_string_matching(/^application-.*.js.gz$/))
         end
 
         it "runs the migrations" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -135,7 +135,7 @@ module Fauxpaas
         end
       end
 
-      context "without rails" do
+      xcontext "without rails" do
         include_context "deploy setup", "test-norails"
         let(:gem) { "pry" }
         let(:source) { Pathname.new("some_source_file.txt") }
@@ -150,14 +150,12 @@ module Fauxpaas
 
         include_examples "a successful deploy"
 
-        it "shared/public/assets 2775" do
-          expect((shared_dir/"public"/"assets").stat.mode & 0o7777).to eql(0o2775)
+        it "current/public/assets 2775" do
+          expect((current_dir/"public"/"assets").stat.mode & 0o7777).to eql(0o2775)
         end
 
-        it "current/public/assets is a symlink to shared/public/assets" do
-          dir = current_dir/"public"/"assets"
-          expect(dir.symlink?).to be true
-          expect(dir.realpath).to eql(shared_dir/"public"/"assets")
+        it "precompiles the assets" do
+          expect(current_dir/"public"/"assets".entries.map { |p| p.to_s }).to contain(a_string_matching(/^application-.*.css.gz$/), a_string_matching(/^application-.*.js.gz$/))
         end
 
         it "runs the migrations" do

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -20,12 +20,20 @@ module Fauxpaas
 
   RSpec.describe Release do
     let(:artifact) { double(:artifact) }
-    let(:deploy_config) { double(:deploy_config, runner: deploy_runner) }
     let(:deploy_runner) { double(:deploy_runner) }
-    before(:each) { allow(deploy_runner).to receive(:deploy).with(artifact) }
+    let(:deploy_config) { double(:deploy_config, runner: deploy_runner) }
+    let(:signature) { double(:signature, deploy: double(:deploy_ref)) }
+    let(:artifact_builder) { double(:artifact_builder, build: artifact) }
+
+    before(:each) do
+      Fauxpaas.config.register(:artifact_builder) { artifact_builder }
+      allow(DeployConfig).to receive(:from_ref).with(signature.deploy, Fauxpaas.ref_repo)
+                         .and_return(deploy_config)
+      allow(deploy_runner).to receive(:deploy).with(artifact)
+    end
 
     let(:release) do
-      described_class.new(artifact: artifact, deploy_config: deploy_config)
+      described_class.new(signature)
     end
 
     describe "#deploy" do


### PR DESCRIPTION
The specs pass, but there are some ugly workarounds for bundler here. I figure this is not so much useful in and of itself, but there are probably a couple useful things here for discussion:

- `ArtifactBuilder#run_command` - although it doesn't do any error checking.

- A possible way to split up the responsibilities between `DeployCommand` and `Release`.

Things to do before I would consider this done:

- AEIM-1363 needs to be done to our satisfaction
- `artifact_builder_spec.rb` needs to use a mocked system runner
- `ArtifactBuilder#run_command` needs to abort the release if a command fails
- We need a way not to run asset precompilation if there are no assets. I had envisioned this being specified in `DeployConfig` and `Release` telling the `ArtifactBuilder` whether or not to do it, but there are several approaches that could work.

There are in general common concerns with some of the other issues we're working on, so I think we probably ought to take a look at the different directions we're going and try to make some decisions.