### PR TITLE
Add a clean_env flag for system runners

### DIFF
--- a/lib/fauxpaas/cap_runner.rb
+++ b/lib/fauxpaas/cap_runner.rb
@@ -16,7 +16,8 @@ module Fauxpaas
     def run(capfile_path, stage, task, options)
       system_runner.run(
         "cap -f #{capfile_path} #{stage} #{task} --trace " \
-          "#{capify_options(options).join(" ")}".strip
+          "#{capify_options(options).join(" ")}".strip,
+          clean_env: false
       )
     end
 

--- a/lib/fauxpaas/open3_capture.rb
+++ b/lib/fauxpaas/open3_capture.rb
@@ -6,8 +6,12 @@ module Fauxpaas
 
   # Runner that uses Open3.capture3
   class Open3Capture
-    def run(string)
-      Bundler.with_clean_env do
+    def run(string, clean_env: true)
+      if clean_env
+        Bundler.with_clean_env do
+          Open3.capture3(string)
+        end
+      else
         Open3.capture3(string)
       end
     end

--- a/lib/fauxpaas/passthrough_runner.rb
+++ b/lib/fauxpaas/passthrough_runner.rb
@@ -10,16 +10,26 @@ module Fauxpaas
       @stream = stream
     end
 
-    def run(command)
-      output = []
-      Bundler.with_clean_env do
-        Open3.popen2e(command) do |_stdin, cmd_output, thread|
-          while line = cmd_output.gets
-            stream.puts line
-            output << line
-          end
-          [output.join, output.join, thread.value]
+    def run(command, clean_env: true)
+      if clean_env
+        Bundler.with_clean_env do
+          run!(command)
         end
+      else
+        run!(command)
+      end
+    end
+
+    private
+
+    def run!(command)
+      output = []
+      Open3.popen2e(command) do |_stdin, cmd_output, thread|
+        while line = cmd_output.gets
+          stream.puts line
+          output << line
+        end
+        [output.join, output.join, thread.value]
       end
     end
 

--- a/spec/cap_runner_spec.rb
+++ b/spec/cap_runner_spec.rb
@@ -16,7 +16,8 @@ module Fauxpaas
     describe "#run" do
       it "runs the correct command" do
         expect(kernel).to receive(:run).with(
-          "cap -f #{capfile_path} myapp-mystage test:task --trace FOO=foo BAR=5 ZIP=zop"
+          "cap -f #{capfile_path} myapp-mystage test:task --trace FOO=foo BAR=5 ZIP=zop",
+          clean_env: false
         )
         runner.run(capfile_path, "myapp-mystage", "test:task",
           foo: "foo",
@@ -28,7 +29,8 @@ module Fauxpaas
         expect(kernel).to receive(:run).with(
           "cap -f #{capfile_path} " + 'myapp-mystage test:task --trace FOO=with\\ spaces ' \
           'BAR=with\\ double\\"\\ quotes BAZ=\\$horrible\\ \\`arg\\` ' \
-          'QUUX=with\\\\backslash'
+          'QUUX=with\\\\backslash',
+          clean_env: false
         )
         runner.run(capfile_path, "myapp-mystage", "test:task",
           foo: "with spaces",


### PR DESCRIPTION
When set to true, this causes the command to be run with a clean
bundler environment.