### PR TITLE
Use rsync to upload files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       capistrano-rbenv
       ettin (~> 1.1.0)
       gli
+      rsync
       terminal-table
 
 GEM
@@ -71,6 +72,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rsync (1.0.9)
     rubocop (0.59.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)

--- a/deploy/cap/source.rb
+++ b/deploy/cap/source.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "pathname"
+require "rsync"
+
+RSYNC_OPTIONS = ["-v", "-r", "-l", "-p", "-z"].freeze
 
 namespace :source do
   task :setup do
@@ -10,9 +13,7 @@ namespace :source do
   desc "Upload source"
   task upload: [:setup] do
     on roles(:all) do
-      Pathname.new(fetch(:source_local_path)).children.each do |path|
-        upload! path.to_s, fetch(:release_path), recursive: path.directory?
-      end
+      Rsync.run("#{fetch(:source_local_path)}/.", "#{fetch(:release_path)}/", RSYNC_OPTIONS)
 
       # We refrain from chmoding the files here because unshared:upload
       # will do it for us.

--- a/fauxpaas.gemspec
+++ b/fauxpaas.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "canister"
   spec.add_runtime_dependency "ettin", "~> 1.1.0"
   spec.add_runtime_dependency "gli"
+  spec.add_runtime_dependency "rsync"
   spec.add_runtime_dependency "terminal-table"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
Uses the ruby-rsync gem to upload instead of sshkit

Resolves AEIM-1530
Compare to #64 

The merit of continuing to do this step in deploy/cap/source.rb is that it is clearer than relying on capistrano's inner SCM machinery. The hope is that will allow us to more easily remove capistrano eventually.

