### PR TITLE
AEIM-1539 - Reintroduce capistrano-bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     fauxpaas (0.2.0)
       canister
       capistrano (~> 3.9.1)
+      capistrano-bundler
       capistrano-rails
       capistrano-rbenv
       ettin (~> 1.1.0)

--- a/deploy/capfiles/norails.capfile
+++ b/deploy/capfiles/norails.capfile
@@ -14,3 +14,4 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
+require "capistrano/bundler"

--- a/deploy/capfiles/rails.capfile
+++ b/deploy/capfiles/rails.capfile
@@ -15,5 +15,6 @@ install_plugin Fauxpaas::DirOnlySCM
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
 require "capistrano/rails/assets"
+require "capistrano/bundler"
 require "capistrano/rails/migrations"
 

--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -18,6 +18,12 @@ set :keep_releases, 5
 set :local_user, "faux"
 set :pty, false
 
+# Configure capistrano-bundler; required only while we are still running rake
+# via Cap, since the assets / migration plugins run system rake otherwise.
+# Alternatively, we could use a binstub and put bin/ on the path to ensure
+# that the bundle is activated.
+set :bundle_roles, :none
+
 # We only link files that would be non-sensical to be release-specific.
 # This notably does not contain developer configuration.
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"

--- a/fauxpaas.gemspec
+++ b/fauxpaas.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "capistrano", "~> 3.9.1"
+  spec.add_runtime_dependency "capistrano-bundler"
   spec.add_runtime_dependency "capistrano-rails"
   spec.add_runtime_dependency "capistrano-rbenv"
   spec.add_runtime_dependency "canister"

--- a/spec/fixtures/integration/capfiles/norails.capfile
+++ b/spec/fixtures/integration/capfiles/norails.capfile
@@ -14,3 +14,4 @@ install_plugin Fauxpaas::DirOnlySCM
 
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
+require "capistrano/bundler"

--- a/spec/fixtures/integration/capfiles/rails.capfile
+++ b/spec/fixtures/integration/capfiles/rails.capfile
@@ -15,5 +15,6 @@ install_plugin Fauxpaas::DirOnlySCM
 # Include tasks from other gems included in your Gemfile
 require "capistrano/rbenv"
 require "capistrano/rails/assets"
+require "capistrano/bundler"
 require "capistrano/rails/migrations"
 


### PR DESCRIPTION
While we're precompiling assets or running migrations with Cap, it needs
capistrano-bundler, or bundle exec is omitted and rake can throw errors.