### PR TITLE
Cleaner integration tests

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
+branches_root: data/cache/branches
 instance_root: data/instances
 releases_root: releases
 deployer_env_root: deploy/capfiles

--- a/lib/fauxpaas.rb
+++ b/lib/fauxpaas.rb
@@ -107,7 +107,8 @@ module Fauxpaas
             c.instance_root,
             c.releases_root,
             c.filesystem,
-            c.git_runner
+            c.git_runner,
+            c.branches_root
           )
         end
         container.register(:permissions_repo) do |c|
@@ -134,6 +135,9 @@ module Fauxpaas
         end
         container.register(:ref_root) do
           Pathname.new(settings.ref_root).expand_path(Fauxpaas.root)
+        end
+        container.register(:branches_root) do
+          Pathname.new(settings.branches_root).expand_path(Fauxpaas.root)
         end
         container.register(:split_token) { settings.split_token.chomp }
         container.register(:unshared_name) { settings.unshared_name.chomp }

--- a/lib/fauxpaas/file_instance_repo.rb
+++ b/lib/fauxpaas/file_instance_repo.rb
@@ -25,11 +25,7 @@ module Fauxpaas
       releases = releases_content(name)
       Instance.new(
         name: name,
-        source: ArchiveReference.new(
-          contents["source"]["url"],
-          branch_for(name) || contents["source"]["commitish"],
-          git_runner
-        ),
+        source: instance_from_hash(name, contents),
         deploy: ArchiveReference.from_hash(contents["deploy"], git_runner),
         shared: ArchiveReference.from_hash([contents["shared"]].flatten.first, git_runner),
         unshared: ArchiveReference.from_hash([contents["unshared"]].flatten.first, git_runner),
@@ -49,6 +45,14 @@ module Fauxpaas
 
     attr_reader :instances_path, :releases_path, :fs, :git_runner, :branches_path
 
+    def instance_from_hash(name, hash)
+      ArchiveReference.new(
+        hash["source"]["url"],
+        branch_for(name) || hash["source"]["commitish"],
+        git_runner
+      )
+    end
+
     def branch_for(name)
       if fs.exists?(path_to_branch(name))
         fs.read(branches_path/name).strip
@@ -57,7 +61,7 @@ module Fauxpaas
 
     def write_branch(name, branch)
       fs.mkdir_p(path_to_branch(name).dirname)
-      fs.write(path_to_branch(name), instance.default_branch)
+      fs.write(path_to_branch(name), branch)
     end
 
     def write_releases(name, releases)

--- a/lib/fauxpaas/file_instance_repo.rb
+++ b/lib/fauxpaas/file_instance_repo.rb
@@ -32,10 +32,6 @@ module Fauxpaas
       )
     end
 
-    def save_instance(instance)
-      write_instance(instance)
-    end
-
     def save_releases(instance)
       write_releases(instance.name, instance.releases)
     end
@@ -43,16 +39,6 @@ module Fauxpaas
     private
 
     attr_reader :instances_path, :releases_path, :fs, :git_runner
-
-    def write_instance(instance)
-      fs.mkdir_p(path_to_instance(instance.name).dirname)
-      fs.write(path_to_instance(instance.name), YAML.dump(
-        "deploy" => instance.deploy.to_hash,
-        "source" => instance.source.to_hash,
-        "shared" => instance.shared.to_hash,
-        "unshared" => instance.unshared.to_hash
-      ))
-    end
 
     def write_releases(name, releases)
       fs.mkdir_p(path_to_release(name).dirname)

--- a/spec/file_instance_repo_spec.rb
+++ b/spec/file_instance_repo_spec.rb
@@ -10,11 +10,12 @@ module Fauxpaas
   RSpec.describe FileInstanceRepo do
     let(:instance_root) { Fauxpaas.root/"spec"/"fixtures"/"unit"/"instances" }
     let(:releases_root) { Fauxpaas.root/"spec"/"fixtures"/"unit"/"releases" }
+    let(:branches_root) { Fauxpaas.root/"spec"/"fixtures"/"unit"/"brances-cache" }
     let(:static_repo) do
-      described_class.new(instance_root, releases_root, Filesystem.new, Fauxpaas.git_runner)
+      described_class.new(instance_root, releases_root, Filesystem.new, Fauxpaas.git_runner, branches_root)
     end
     let(:mem_fs) { MemoryFilesystem.new }
-    let(:tmp_repo) { described_class.new("/instances", "/releases", mem_fs, Fauxpaas.git_runner) }
+    let(:tmp_repo) { described_class.new("/instances", "/releases", mem_fs, Fauxpaas.git_runner, "/branches") }
 
     describe "#find" do
       it "can find legacy instances" do

--- a/spec/file_instance_repo_spec.rb
+++ b/spec/file_instance_repo_spec.rb
@@ -16,39 +16,33 @@ module Fauxpaas
     let(:mem_fs) { MemoryFilesystem.new }
     let(:tmp_repo) { described_class.new("/instances", "/releases", mem_fs, Fauxpaas.git_runner) }
 
-    describe "#save_instance" do
-      it "find legacy instances" do
+    describe "#find" do
+      it "can find legacy instances" do
         instance = static_repo.find("test-legacypersistence")
-        tmp_repo.save_instance(instance)
-        updated_contents = YAML.load(File.read(instance_root/"test-persistence"/"instance.yml"))
-        expect(YAML.load(mem_fs.read("/instances/test-legacypersistence/instance.yml")))
-          .to eql(updated_contents)
+        expect(instance.deploy.url).to   eql("git@github.com:mlibrary/faux-deploy")
+        expect(instance.source.url).to   eql("https://github.com/dpn-admin/dpn-client.git")
+        expect(instance.shared.url).to   eql("git@github.com:mlibrary/faux-infrastructure")
+        expect(instance.unshared.url).to eql("git@github.com:mlibrary/faux-dev")
+        expect(instance.deploy.commitish).to   eql("test-norails")
+        expect(instance.source.commitish).to   eql("master")
+        expect(instance.shared.commitish).to   eql("test-norails")
+        expect(instance.unshared.commitish).to eql("test-norails")
       end
-      it "can save and find instances" do
-        contents_before = YAML.load(File.read(instance_root/"test-persistence"/"instance.yml"))
-        instance = static_repo.find("test-persistence")
-        tmp_repo.save_instance(instance)
-        expect(YAML.load(mem_fs.read("/instances/test-persistence/instance.yml")))
-          .to eql(contents_before)
-      end
-
-      it "creates the directories to save in" do
-        expect(mem_fs).to receive(:mkdir_p).with(Pathname.new("/instances/test-persistence"))
-        instance = static_repo.find("test-persistence")
-        tmp_repo.save_instance(instance)
+      it "can find instances" do
+        instance = static_repo.find("test-legacypersistence")
+        expect(instance.deploy.url).to   eql("git@github.com:mlibrary/faux-deploy")
+        expect(instance.source.url).to   eql("https://github.com/dpn-admin/dpn-client.git")
+        expect(instance.shared.url).to   eql("git@github.com:mlibrary/faux-infrastructure")
+        expect(instance.unshared.url).to eql("git@github.com:mlibrary/faux-dev")
+        expect(instance.deploy.commitish).to   eql("test-norails")
+        expect(instance.source.commitish).to   eql("master")
+        expect(instance.shared.commitish).to   eql("test-norails")
+        expect(instance.unshared.commitish).to eql("test-norails")
       end
     end
 
     describe "#save_releases" do
-      it "find legacy releases" do
-        instance = static_repo.find("test-legacypersistence")
-        tmp_repo.save_releases(instance)
-        updated_contents = YAML.load(File.read(releases_root/"test-persistence.yml"))
-        expect(YAML.load(mem_fs.read("/releases/test-legacypersistence.yml")))
-          .to eql(updated_contents)
-      end
-
-      it "can save and find releases" do
+      it "can save releases" do
         contents_before = YAML.load(File.read(releases_root/"test-persistence.yml"))
         instance = static_repo.find("test-persistence")
         tmp_repo.save_releases(instance)

--- a/spec/fixtures/integration/instances/test-norails/hosts.rb
+++ b/spec/fixtures/integration/instances/test-norails/hosts.rb
@@ -3,7 +3,8 @@
 require "tmpdir"
 require "pathname"
 
-deploy_to = File.join(Dir.tmpdir, "fauxpaas", "sandbox", "test-norails")
+test_deploy_locator = Pathname.new(__FILE__)/"../../../../../sandbox/test_deploy_root"
+deploy_to = File.read(test_deploy_locator).strip
 `mkdir -p #{deploy_to}`
 
 set :deploy_to, deploy_to

--- a/spec/fixtures/integration/instances/test-rails/hosts.rb
+++ b/spec/fixtures/integration/instances/test-rails/hosts.rb
@@ -3,7 +3,8 @@
 require "tmpdir"
 require "pathname"
 
-deploy_to = File.join(Dir.tmpdir, "fauxpaas", "sandbox", "test-rails")
+test_deploy_locator = Pathname.new(__FILE__)/"../../../../../sandbox/test_deploy_root"
+deploy_to = File.read(test_deploy_locator).strip
 `mkdir -p #{deploy_to}`
 
 set :deploy_to, deploy_to

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -33,13 +33,13 @@ module Fauxpaas
             config.register(:test_run_root) {|c| c.project_root/"sandbox"/c.test_run_id}
             config.register(:fixtures_root) {|c| c.project_root/"spec"/"fixtures"/"integration" }
             config.register(:fixtures_path) {|c| c.fixtures_root } # delete me
+            config.register(:deploy_root) {|c| c.test_run_root/"deploy"}
+            config.register(:test_deploy_locator) {|c| c.project_root/"sandbox"/"test_deploy_root"}
 
             # Configure the application
             config.register(:instance_root) {|c| c.test_run_root/"instances"}
             config.register(:releases_root) {|c| c.test_run_root/"releases" }
             config.register(:deployer_env_root) {|c| c.test_run_root/"capfiles" }
-
-            config.register(:deploy_root) { Pathname.new(Dir.tmpdir)/"fauxpaas"/"sandbox"/instance_name }
 
             # Configure the logger
             config.register(:git_runner) { FileRunner.new }
@@ -53,12 +53,18 @@ module Fauxpaas
 
           @fauxpaas = Fauxpaas.config
           FileUtils.mkdir_p Fauxpaas.deploy_root
-          FileUtils.cp_r(Fauxpaas.fixtures_root, Fauxpaas.test_run_root)
+          FileUtils.mkdir_p Fauxpaas.test_run_root
+          FileUtils.copy_entry("#{Fauxpaas.fixtures_root}/.", Fauxpaas.test_run_root)
+
+          # The integration capfiles use this file to find the deploy_root
+          File.write(Fauxpaas.test_deploy_locator, Fauxpaas.deploy_root)
+
         end
         after(:all) do
           FileUtils.rm_rf @fauxpaas.test_run_root
           FileUtils.rm_rf @fauxpaas.deploy_root
           FileUtils.rm_rf @fauxpaas.ref_root
+          FileUtils.rm @fauxpaas.test_deploy_locator
         end
         let(:root) { @fauxpaas.deploy_root }
         let(:current_dir) { root/"current" }


### PR DESCRIPTION
This is a combination of some effort to simplify DeployConfig's needs in AEIM-1366, and an effort to get the integration tests to run in capistrano. They still don't, but this at least cleans them up a bit.